### PR TITLE
Drastically reduce the NFs image footprints

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.12.9-stretch AS builder
 
-LABEL maintainer="Free5GC <support@free5gc.org>""
+LABEL maintainer="Free5GC <support@free5gc.org>"
 
 ENV GO111MODULE=off
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.12.9-stretch AS builder
 
-MAINTAINER free5GC <support@free5gc.org>
+LABEL maintainer="Free5GC <support@free5gc.org>""
 
 ENV GO111MODULE=off
 
@@ -16,7 +16,7 @@ RUN cd $GOPATH/src \
 
 # Build NF (AMF, AUSF, N3IWF, NRF, NSSF, PCF, SMF, UDM, UDR)
 RUN cd $GOPATH/src/free5gc/src \
-    && for d in * ; do if [ -f "$d/$d.go" ] ; then go build -o ../bin/"$d" -x "$d/$d.go" ; fi ; done ;
+    && for d in * ; do if [ -f "$d/$d.go" ] ; then CGO_ENABLED=0 go build -a -installsuffix nocgo -o ../bin/"$d" -x "$d/$d.go" ; fi ; done ;
 
 # Build UPF
 #RUN go get -u -v "github.com/sirupsen/logrus"

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -29,7 +29,7 @@ RUN cd $GOPATH/src/free5gc/src/upf \
 # Build WebUI
 RUN cd $GOPATH/src/free5gc/webconsole \
     && git checkout --detach cbf7ec1 \
-    && go build -o webui -x server.go
+    && CGO_ENABLED=0 go build -a -installsuffix nocgo -o webui -x server.go
 
 # Alpine is used for debug purpose. You can use scratch for a smaller footprint.
 FROM alpine

--- a/config/n3iwf-ipsec.sh
+++ b/config/n3iwf-ipsec.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+### N3iwf IPSec tunnel configuration
+
+ip l add name ipsec0 type vti local \$(hostname -i | awk '{print \$1}') remote 0.0.0.0 key 5
+ip a add 10.0.0.1/24 dev ipsec0
+ip l set dev ipsec0 up

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -247,8 +247,8 @@ services:
       args:
         DEBUG_TOOLS: "false"
     command: |
-      /bin/bash -c "
-        ip l add name ipsec0 type vti local $$(hostname -I | awk '{print $$1}') remote 0.0.0.0 key 5
+      /bin/sh -c "
+        ip l add name ipsec0 type vti local $$(hostname -i | awk '{print $$1}') remote 0.0.0.0 key 5
         ip a add 10.0.0.1/24 dev ipsec0
         ip l set dev ipsec0 up
         ./n3iwf -n3iwfcfg ../config/n3iwfcfg.conf

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
       context: ./nf_upf
       args:
         DEBUG_TOOLS: "false"
+    command: ./free5gc-upfd -f ../config/upfcfg.yaml
     volumes:
       - "./config/upfcfg1.yaml:/free5gc/config/upfcfg.yaml"
     cap_add:
@@ -22,6 +23,7 @@ services:
       context: ./nf_upf
       args:
         DEBUG_TOOLS: "false"
+    command: ./free5gc-upfd -f ../config/upfcfg.yaml
     volumes:
       - ./config/upfcfg2.yaml:/free5gc/config/upfcfg.yaml
     cap_add:
@@ -37,6 +39,7 @@ services:
       context: ./nf_upf
       args:
         DEBUG_TOOLS: "false"
+    command: ./free5gc-upfd -f ../config/upfcfg.yaml
     volumes:
       - ./config/upfcfgb.yaml:/free5gc/config/upfcfg.yaml
     cap_add:
@@ -65,6 +68,7 @@ services:
       context: ./nf_nrf
       args:
         DEBUG_TOOLS: "false"
+    command: ./nrf -nrfcfg ../config/nrfcfg.conf
     expose:
       - "29510"
     volumes:
@@ -86,6 +90,7 @@ services:
       context: ./nf_amf
       args:
         DEBUG_TOOLS: "false"
+    command: ./amf -amfcfg ../config/amfcfg.conf
     expose:
       - "29518"
     volumes:
@@ -106,6 +111,7 @@ services:
       context: ./nf_ausf
       args:
         DEBUG_TOOLS: "false"
+    command: ./ausf -ausfcfg ../config/ausfcfg.conf
     expose:
       - "29509"
     volumes:
@@ -126,6 +132,7 @@ services:
       context: ./nf_nssf
       args:
         DEBUG_TOOLS: "false"
+    command: ./nssf -nssfcfg ../config/nssfcfg.conf
     expose:
       - "29531"
     volumes:
@@ -146,6 +153,7 @@ services:
       context: ./nf_pcf
       args:
         DEBUG_TOOLS: "false"
+    command: ./pcf -pcfcfg ../config/pcfcfg.conf
     expose:
       - "29507"
     volumes:
@@ -166,6 +174,7 @@ services:
       context: ./nf_smf
       args:
         DEBUG_TOOLS: "false"
+    command: ./smf -smfcfg ../config/smfcfg.conf -uerouting ../config/uerouting.yaml
     expose:
       - "29502"
     volumes:
@@ -190,6 +199,7 @@ services:
       context: ./nf_udm
       args:
         DEBUG_TOOLS: "false"
+    command: ./udm -udmcfg ../config/udmcfg.conf
     expose:
       - "29503"
     volumes:
@@ -211,6 +221,7 @@ services:
       context: ./nf_udr
       args:
         DEBUG_TOOLS: "false"
+    command: ./udr -udrcfg ../config/udrcfg.conf
     expose:
       - "29504"
     environment:
@@ -235,9 +246,11 @@ services:
       context: ./nf_n3iwf
       args:
         DEBUG_TOOLS: "false"
+    command: ./n3iwf-ipsec.sh && ./n3iwf -n3iwfcfg ../config/n3iwfcfg.conf
     volumes:
       - ./config/n3iwfcfg.conf:/free5gc/config/n3iwfcfg.conf
       - ./config/free5GC.conf:/free5gc/config/free5GC.conf
+      - ./config/n3iwf-ipsec.sh:/free5gc/n3iwf/n3iwf-ipsec.sh
     environment:
       GIN_MODE: release
     cap_add:
@@ -257,6 +270,7 @@ services:
       context: ./webui
       args:
         DEBUG_TOOLS: "false"
+    command: ./webui
     volumes:
       - ./config/webuicfg.conf:/free5gc/config/webuicfg.conf
       - ./config/free5GC.conf:/free5gc/config/free5GC.conf

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,9 +7,8 @@ services:
       context: ./nf_upf
       args:
         DEBUG_TOOLS: "false"
-    command: ./free5gc-upfd -f ../config/upfcfg1.yaml
     volumes:
-      - "./config/upfcfg1.yaml:/free5gc/config/upfcfg1.yaml"
+      - "./config/upfcfg1.yaml:/free5gc/config/upfcfg.yaml"
     cap_add:
       - NET_ADMIN
     networks:
@@ -23,9 +22,8 @@ services:
       context: ./nf_upf
       args:
         DEBUG_TOOLS: "false"
-    command: ./free5gc-upfd -f ../config/upfcfg2.yaml
     volumes:
-      - ./config/upfcfg2.yaml:/free5gc/config/upfcfg2.yaml
+      - ./config/upfcfg2.yaml:/free5gc/config/upfcfg.yaml
     cap_add:
       - NET_ADMIN
     networks:
@@ -39,9 +37,8 @@ services:
       context: ./nf_upf
       args:
         DEBUG_TOOLS: "false"
-    command: ./free5gc-upfd -f ../config/upfcfgb.yaml
     volumes:
-      - ./config/upfcfgb.yaml:/free5gc/config/upfcfgb.yaml
+      - ./config/upfcfgb.yaml:/free5gc/config/upfcfg.yaml
     cap_add:
       - NET_ADMIN
     networks:
@@ -68,7 +65,6 @@ services:
       context: ./nf_nrf
       args:
         DEBUG_TOOLS: "false"
-    command: ./nrf -nrfcfg ../config/nrfcfg.conf
     expose:
       - "29510"
     volumes:
@@ -90,7 +86,6 @@ services:
       context: ./nf_amf
       args:
         DEBUG_TOOLS: "false"
-    command: ./amf -amfcfg ../config/amfcfg.conf
     expose:
       - "29518"
     volumes:
@@ -111,7 +106,6 @@ services:
       context: ./nf_ausf
       args:
         DEBUG_TOOLS: "false"
-    command: ./ausf -ausfcfg ../config/ausfcfg.conf
     expose:
       - "29509"
     volumes:
@@ -132,7 +126,6 @@ services:
       context: ./nf_nssf
       args:
         DEBUG_TOOLS: "false"
-    command: ./nssf -nssfcfg ../config/nssfcfg.conf
     expose:
       - "29531"
     volumes:
@@ -153,7 +146,6 @@ services:
       context: ./nf_pcf
       args:
         DEBUG_TOOLS: "false"
-    command: ./pcf -pcfcfg ../config/pcfcfg.conf
     expose:
       - "29507"
     volumes:
@@ -174,7 +166,6 @@ services:
       context: ./nf_smf
       args:
         DEBUG_TOOLS: "false"
-    command: ./smf -smfcfg ../config/smfcfg.conf -uerouting ../config/uerouting.yaml
     expose:
       - "29502"
     volumes:
@@ -199,7 +190,6 @@ services:
       context: ./nf_udm
       args:
         DEBUG_TOOLS: "false"
-    command: ./udm -udmcfg ../config/udmcfg.conf
     expose:
       - "29503"
     volumes:
@@ -221,7 +211,6 @@ services:
       context: ./nf_udr
       args:
         DEBUG_TOOLS: "false"
-    command: ./udr -udrcfg ../config/udrcfg.conf
     expose:
       - "29504"
     environment:
@@ -246,13 +235,6 @@ services:
       context: ./nf_n3iwf
       args:
         DEBUG_TOOLS: "false"
-    command: |
-      /bin/sh -c "
-        ip l add name ipsec0 type vti local $$(hostname -i | awk '{print $$1}') remote 0.0.0.0 key 5
-        ip a add 10.0.0.1/24 dev ipsec0
-        ip l set dev ipsec0 up
-        ./n3iwf -n3iwfcfg ../config/n3iwfcfg.conf
-      "
     volumes:
       - ./config/n3iwfcfg.conf:/free5gc/config/n3iwfcfg.conf
       - ./config/free5GC.conf:/free5gc/config/free5GC.conf
@@ -275,12 +257,11 @@ services:
       context: ./webui
       args:
         DEBUG_TOOLS: "false"
-    command: ./webui
     volumes:
       - ./config/webuicfg.conf:/free5gc/config/webuicfg.conf
       - ./config/free5GC.conf:/free5gc/config/free5GC.conf
     environment:
-      - GIN_MODE=debug
+      - GIN_MODE=release
     networks:
       privnet:
         aliases:

--- a/nf_amf/Dockerfile
+++ b/nf_amf/Dockerfile
@@ -30,5 +30,3 @@ VOLUME [ "/free5gc/support/TLS" ]
 
 # Exposed ports
 EXPOSE 29518
-
-CMD [ "./amf", "-amfcfg", "../config/amfcfg.conf" ]

--- a/nf_amf/Dockerfile
+++ b/nf_amf/Dockerfile
@@ -30,3 +30,5 @@ VOLUME [ "/free5gc/support/TLS" ]
 
 # Exposed ports
 EXPOSE 29518
+
+CMD [ "./amf", "-amfcfg", "../config/amfcfg.conf" ]

--- a/nf_amf/Dockerfile
+++ b/nf_amf/Dockerfile
@@ -1,15 +1,14 @@
 FROM free5gc-base-v3:latest AS builder
-FROM ubuntu:18.04
+FROM alpine:3.8
 
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
 ENV F5GC_MODULE amf
-ENV DEBIAN_FRONTEND noninteractive
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
-RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apt-get update && apt-get install -y vim strace net-tools iputils-ping curl netcat ; fi
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
 
 # Set working dir
 WORKDIR /free5gc

--- a/nf_ausf/Dockerfile
+++ b/nf_ausf/Dockerfile
@@ -30,5 +30,3 @@ VOLUME [ "/free5gc/support/TLS" ]
 
 # Exposed ports
 EXPOSE 29509
-
-CMD [ "./ausf", "-ausfcfg", "../config/ausfcfg.conf" ]

--- a/nf_ausf/Dockerfile
+++ b/nf_ausf/Dockerfile
@@ -30,3 +30,5 @@ VOLUME [ "/free5gc/support/TLS" ]
 
 # Exposed ports
 EXPOSE 29509
+
+CMD [ "./ausf", "-ausfcfg", "../config/ausfcfg.conf" ]

--- a/nf_ausf/Dockerfile
+++ b/nf_ausf/Dockerfile
@@ -1,15 +1,14 @@
 FROM free5gc-base-v3:latest AS builder
-FROM ubuntu:18.04
+FROM alpine:3.8
 
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
 ENV F5GC_MODULE ausf
-ENV DEBIAN_FRONTEND noninteractive
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
-RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apt-get update && apt-get install -y vim strace net-tools iputils-ping curl netcat ; fi
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
 
 # Set working dir
 WORKDIR /free5gc

--- a/nf_n3iwf/Dockerfile
+++ b/nf_n3iwf/Dockerfile
@@ -25,13 +25,8 @@ COPY --from=builder /free5gc/support/TLS/${F5GC_MODULE}.key ./support/TLS/
 # Move to the binary path
 WORKDIR /free5gc/${F5GC_MODULE}
 
-RUN printf "#!/bin/sh \n\n### Start n3iwf \n\nip l add name ipsec0 type vti local \$(hostname -i | awk '{print \$1}') remote 0.0.0.0 key 5 \nip a add 10.0.0.1/24 dev ipsec0 \nip l set dev ipsec0 up \n\n./n3iwf -n3iwfcfg ../config/n3iwfcfg.conf\n" > start-n3iwf.sh \
-    && chmod +x start-n3iwf.sh
-
 # Config files volume
 VOLUME [ "/free5gc/config" ]
 
 # Certificates (if not using default) volume
 VOLUME [ "/free5gc/support/TLS" ]
-
-CMD [ "./start-n3iwf.sh" ]

--- a/nf_n3iwf/Dockerfile
+++ b/nf_n3iwf/Dockerfile
@@ -1,20 +1,17 @@
 FROM free5gc-base-v3:latest AS builder
-FROM ubuntu:18.04
+FROM alpine:3.8
 
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
 ENV F5GC_MODULE n3iwf
-ENV DEBIAN_FRONTEND noninteractive
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
-RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apt-get update && apt-get install -y vim strace net-tools iputils-ping curl netcat ; fi
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
 
-# Install UPF dependencies
-RUN apt-get update \
-    && apt-get install -y iproute2 netbase \
-    && apt-get clean
+# Install N3IWF dependencies
+RUN apk add -U iproute2
 
 # Set working dir
 WORKDIR /free5gc

--- a/nf_n3iwf/Dockerfile
+++ b/nf_n3iwf/Dockerfile
@@ -25,8 +25,13 @@ COPY --from=builder /free5gc/support/TLS/${F5GC_MODULE}.key ./support/TLS/
 # Move to the binary path
 WORKDIR /free5gc/${F5GC_MODULE}
 
+RUN printf "#!/bin/sh \n\n### Start n3iwf \n\nip l add name ipsec0 type vti local \$(hostname -i | awk '{print \$1}') remote 0.0.0.0 key 5 \nip a add 10.0.0.1/24 dev ipsec0 \nip l set dev ipsec0 up \n\n./n3iwf -n3iwfcfg ../config/n3iwfcfg.conf\n" > start-n3iwf.sh \
+    && chmod +x start-n3iwf.sh
+
 # Config files volume
 VOLUME [ "/free5gc/config" ]
 
 # Certificates (if not using default) volume
 VOLUME [ "/free5gc/support/TLS" ]
+
+CMD [ "./start-n3iwf.sh" ]

--- a/nf_nrf/Dockerfile
+++ b/nf_nrf/Dockerfile
@@ -30,3 +30,5 @@ VOLUME [ "/free5gc/support/TLS" ]
 
 # Exposed ports
 EXPOSE 29510
+
+CMD [ "./nrf", "-nrfcfg", "../config/nrfcfg.conf" ]

--- a/nf_nrf/Dockerfile
+++ b/nf_nrf/Dockerfile
@@ -1,15 +1,14 @@
 FROM free5gc-base-v3:latest AS builder
-FROM ubuntu:18.04
+FROM alpine:3.8
 
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
 ENV F5GC_MODULE nrf
-ENV DEBIAN_FRONTEND noninteractive
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
-RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apt-get update && apt-get install -y vim strace net-tools iputils-ping curl netcat ; fi
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
 
 # Set working dir
 WORKDIR /free5gc

--- a/nf_nrf/Dockerfile
+++ b/nf_nrf/Dockerfile
@@ -30,5 +30,3 @@ VOLUME [ "/free5gc/support/TLS" ]
 
 # Exposed ports
 EXPOSE 29510
-
-CMD [ "./nrf", "-nrfcfg", "../config/nrfcfg.conf" ]

--- a/nf_nssf/Dockerfile
+++ b/nf_nssf/Dockerfile
@@ -30,3 +30,5 @@ VOLUME [ "/free5gc/support/TLS" ]
 
 # Exposed ports
 EXPOSE 29531
+
+CMD [ "./nssf", "-nssfcfg", "../config/nssfcfg.conf" ]

--- a/nf_nssf/Dockerfile
+++ b/nf_nssf/Dockerfile
@@ -30,5 +30,3 @@ VOLUME [ "/free5gc/support/TLS" ]
 
 # Exposed ports
 EXPOSE 29531
-
-CMD [ "./nssf", "-nssfcfg", "../config/nssfcfg.conf" ]

--- a/nf_nssf/Dockerfile
+++ b/nf_nssf/Dockerfile
@@ -1,15 +1,14 @@
 FROM free5gc-base-v3:latest AS builder
-FROM ubuntu:18.04
+FROM alpine:3.8
 
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
 ENV F5GC_MODULE nssf
-ENV DEBIAN_FRONTEND noninteractive
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
-RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apt-get update && apt-get install -y vim strace net-tools iputils-ping curl netcat ; fi
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
 
 # Set working dir
 WORKDIR /free5gc

--- a/nf_pcf/Dockerfile
+++ b/nf_pcf/Dockerfile
@@ -1,15 +1,14 @@
 FROM free5gc-base-v3:latest AS builder
-FROM ubuntu:18.04
+FROM alpine:3.8
 
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
 ENV F5GC_MODULE pcf
-ENV DEBIAN_FRONTEND noninteractive
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
-RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apt-get update && apt-get install -y vim strace net-tools iputils-ping curl netcat ; fi
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
 
 # Set working dir
 WORKDIR /free5gc

--- a/nf_pcf/Dockerfile
+++ b/nf_pcf/Dockerfile
@@ -30,5 +30,3 @@ VOLUME [ "/free5gc/support/TLS" ]
 
 # Exposed ports
 EXPOSE 29507
-
-CMD [ "./pcf", "-pcfcfg", "../config/pcfcfg.conf" ]

--- a/nf_pcf/Dockerfile
+++ b/nf_pcf/Dockerfile
@@ -30,3 +30,5 @@ VOLUME [ "/free5gc/support/TLS" ]
 
 # Exposed ports
 EXPOSE 29507
+
+CMD [ "./pcf", "-pcfcfg", "../config/pcfcfg.conf" ]

--- a/nf_smf/Dockerfile
+++ b/nf_smf/Dockerfile
@@ -30,3 +30,5 @@ VOLUME [ "/free5gc/support/TLS" ]
 
 # Exposed ports
 EXPOSE 29502
+
+CMD [ "./smf", "-smfcfg", "../config/smfcfg.conf", "-uerouting", "../config/uerouting.yaml" ]

--- a/nf_smf/Dockerfile
+++ b/nf_smf/Dockerfile
@@ -30,5 +30,3 @@ VOLUME [ "/free5gc/support/TLS" ]
 
 # Exposed ports
 EXPOSE 29502
-
-CMD [ "./smf", "-smfcfg", "../config/smfcfg.conf", "-uerouting", "../config/uerouting.yaml" ]

--- a/nf_smf/Dockerfile
+++ b/nf_smf/Dockerfile
@@ -1,15 +1,14 @@
 FROM free5gc-base-v3:latest AS builder
-FROM ubuntu:18.04
+FROM alpine:3.8
 
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
 ENV F5GC_MODULE smf
-ENV DEBIAN_FRONTEND noninteractive
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
-RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apt-get update && apt-get install -y vim strace net-tools iputils-ping curl netcat ; fi
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
 
 # Set working dir
 WORKDIR /free5gc

--- a/nf_udm/Dockerfile
+++ b/nf_udm/Dockerfile
@@ -30,3 +30,5 @@ VOLUME [ "/free5gc/support/TLS" ]
 
 # Exposed ports
 EXPOSE 29503
+
+CMD [ "./udm", "-udmcfg", "../config/udmcfg.conf" ]

--- a/nf_udm/Dockerfile
+++ b/nf_udm/Dockerfile
@@ -1,15 +1,14 @@
 FROM free5gc-base-v3:latest AS builder
-FROM ubuntu:18.04
+FROM alpine:3.8
 
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
 ENV F5GC_MODULE udm
-ENV DEBIAN_FRONTEND noninteractive
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
-RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apt-get update && apt-get install -y vim strace net-tools iputils-ping curl netcat ; fi
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
 
 # Set working dir
 WORKDIR /free5gc

--- a/nf_udm/Dockerfile
+++ b/nf_udm/Dockerfile
@@ -30,5 +30,3 @@ VOLUME [ "/free5gc/support/TLS" ]
 
 # Exposed ports
 EXPOSE 29503
-
-CMD [ "./udm", "-udmcfg", "../config/udmcfg.conf" ]

--- a/nf_udr/Dockerfile
+++ b/nf_udr/Dockerfile
@@ -30,5 +30,3 @@ VOLUME [ "/free5gc/support/TLS" ]
 
 # Exposed ports
 EXPOSE 29504
-
-CMD [ "./udr", "-udrcfg", "../config/udrcfg.conf" ]

--- a/nf_udr/Dockerfile
+++ b/nf_udr/Dockerfile
@@ -1,15 +1,14 @@
 FROM free5gc-base-v3:latest AS builder
-FROM ubuntu:18.04
+FROM alpine:3.8
 
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
 ENV F5GC_MODULE udr
-ENV DEBIAN_FRONTEND noninteractive
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
-RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apt-get update && apt-get install -y vim strace net-tools iputils-ping curl netcat ; fi
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
 
 # Set working dir
 WORKDIR /free5gc

--- a/nf_udr/Dockerfile
+++ b/nf_udr/Dockerfile
@@ -30,3 +30,5 @@ VOLUME [ "/free5gc/support/TLS" ]
 
 # Exposed ports
 EXPOSE 29504
+
+CMD [ "./udr", "-udrcfg", "../config/udrcfg.conf" ]

--- a/nf_upf/Dockerfile
+++ b/nf_upf/Dockerfile
@@ -32,3 +32,5 @@ WORKDIR /free5gc/${F5GC_MODULE}
 
 # Update links
 RUN ldconfig
+
+CMD [ "./free5gc-upfd", "-f", "../config/upfcfg.yaml" ]

--- a/nf_upf/Dockerfile
+++ b/nf_upf/Dockerfile
@@ -32,5 +32,3 @@ WORKDIR /free5gc/${F5GC_MODULE}
 
 # Update links
 RUN ldconfig
-
-CMD [ "./free5gc-upfd", "-f", "../config/upfcfg.yaml" ]

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -26,3 +26,5 @@ VOLUME [ "/free5gc/config" ]
 
 # WebUI uses the port 5000
 EXPOSE 5000
+
+CMD [ "./webui" ]

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -26,5 +26,3 @@ VOLUME [ "/free5gc/config" ]
 
 # WebUI uses the port 5000
 EXPOSE 5000
-
-CMD [ "./webui" ]

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -1,15 +1,14 @@
 FROM free5gc-base-v3:latest AS builder
-FROM ubuntu:18.04
+FROM alpine:3.8
 
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
 ENV F5GC_MODULE webui
-ENV DEBIAN_FRONTEND noninteractive
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
-RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apt-get update && apt-get install -y vim strace net-tools iputils-ping curl netcat ; fi
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
 
 # Set working dir
 WORKDIR /free5gc


### PR DESCRIPTION
Hi,

This is a continuity of the work of optimizing the generated docker images. With this, most of the images have a footprint of ~30MB :smile: :muscle: except for the `UPF` :disappointed: 

The modifications include building statically linked binaries and into alpine-based images. The `UPF` was not modified because I had a though time trying to generate a statically linked binary for it but without success (I tried playing with the `CMakeLists.txt` file but I got an `utlt_logger` `ld` issue). Your help will be very welcome.

In the meanwhile, I updated the docker-compose file to make it more cleaner by placing the command entries in the corresponding dockerfiles.

Note: I made the images available here https://hub.docker.com/orgs/dockerfree5gc/repositories.

BR,
