### PR TITLE
Webui image build fails when DEBUG_TOOLS = true

### DIFF
--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -1,14 +1,15 @@
 FROM free5gc/base:latest AS builder
-FROM bitnami/minideb:stretch
+FROM bitnami/minideb:bullseye
 
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
 ENV F5GC_MODULE webui
+ENV DEBIAN_FRONTEND noninteractive
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
-RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apt-get update && apt-get install -y vim strace net-tools curl netcat-openbsd ; fi
 
 # Set working dir
 WORKDIR /free5gc


### PR DESCRIPTION
This PR proposes the following changes to resolve issue #41  - 
- Change webui package manager from apk to apt
- It also upgrades webui base image to debian bullseye release
- also adds base env variable DEBIAN_FRONTEND