### PR TITLE
Add support to build NFs (or specific NF) from free5gc sources located at the host.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,39 @@
 DOCKER_IMAGE_OWNER = 'free5gc'
 DOCKER_IMAGE_NAME = 'base'
+DOCKER_IMAGE_NAME_SLIM = 'base-slim'
 DOCKER_IMAGE_TAG = 'latest'
 
 .PHONY: base
+all: base-slim amf ausf nrf nssf pcf smf udm udr n3iwf upf webconsole
+
 base:
 	docker build -t ${DOCKER_IMAGE_OWNER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} ./base
 	docker image ls ${DOCKER_IMAGE_OWNER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
+
+base-slim:
+	docker build -t ${DOCKER_IMAGE_OWNER}/${DOCKER_IMAGE_NAME_SLIM}:${DOCKER_IMAGE_TAG} -f ./base/Dockerfile.base-slim ./base
+	docker image ls ${DOCKER_IMAGE_OWNER}/${DOCKER_IMAGE_NAME_SLIM}:${DOCKER_IMAGE_TAG}
+
+smf: base-slim
+	docker build --build-arg F5GC_MODULE=smf -t ${DOCKER_IMAGE_OWNER}/smf-base:${DOCKER_IMAGE_TAG} -f ./base/Dockerfile.base-slim.nf ./base
+amf: base-slim
+	docker build --build-arg F5GC_MODULE=amf -t ${DOCKER_IMAGE_OWNER}/amf-base:${DOCKER_IMAGE_TAG} -f ./base/Dockerfile.base-slim.nf ./base
+upf: base-slim
+	docker build --build-arg F5GC_MODULE=upf -t ${DOCKER_IMAGE_OWNER}/upf-base:${DOCKER_IMAGE_TAG} -f ./base/Dockerfile.base-slim.nf ./base
+udr: base-slim
+	docker build --build-arg F5GC_MODULE=udr -t ${DOCKER_IMAGE_OWNER}/udr-base:${DOCKER_IMAGE_TAG} -f ./base/Dockerfile.base-slim.nf ./base
+udm: base-slim
+	docker build --build-arg F5GC_MODULE=udm -t ${DOCKER_IMAGE_OWNER}/udm-base:${DOCKER_IMAGE_TAG} -f ./base/Dockerfile.base-slim.nf ./base
+nrf: base-slim
+	docker build --build-arg F5GC_MODULE=nrf -t ${DOCKER_IMAGE_OWNER}/nrf-base:${DOCKER_IMAGE_TAG} -f ./base/Dockerfile.base-slim.nf ./base
+nssf: base-slim
+	docker build --build-arg F5GC_MODULE=nssf -t ${DOCKER_IMAGE_OWNER}/nssf-base:${DOCKER_IMAGE_TAG} -f ./base/Dockerfile.base-slim.nf ./base
+n3iwf: base-slim
+	docker build --build-arg F5GC_MODULE=n3iwf -t ${DOCKER_IMAGE_OWNER}/n3iwf-base:${DOCKER_IMAGE_TAG} -f ./base/Dockerfile.base-slim.nf ./base
+pcf: base-slim
+	docker build --build-arg F5GC_MODULE=pcf -t ${DOCKER_IMAGE_OWNER}/pcf-base:${DOCKER_IMAGE_TAG} -f ./base/Dockerfile.base-slim.nf ./base
+ausf: base-slim
+	docker build --build-arg F5GC_MODULE=ausf -t ${DOCKER_IMAGE_OWNER}/ausf-base:${DOCKER_IMAGE_TAG} -f ./base/Dockerfile.base-slim.nf ./base
+
+webconsole: base-slim
+	docker build -t ${DOCKER_IMAGE_OWNER}/webconsole-base:${DOCKER_IMAGE_TAG} -f ./base/Dockerfile.base-slim.webconsole ./base

--- a/README.md
+++ b/README.md
@@ -33,6 +33,27 @@ make base
 docker compose -f docker-compose-build.yaml build
 ```
 
+### [Optional 2] Build docker images from local sources
+
+```bash
+# Clone the project
+git clone https://github.com/free5gc/free5gc-compose.git
+cd free5gc-compose
+
+# clone free5gc sources (e.g. v3.2.1)
+cd base
+git clone --recursive -b v3.2.1 -j `nproc` https://github.com/free5gc/free5gc.git
+cd ..
+
+# Build the images
+make all
+docker compose -f docker-compose-build-nf.yaml build
+
+# Alternatively you can build specific NF image e.g.:
+make amf
+docker compose -f docker-compose-build-nf.yaml build free5gc-amf
+```
+
 
 ### Run free5GC
 
@@ -41,6 +62,8 @@ You can create free5GC containers based on local images or docker hub images:
 ```bash
 # use local images
 docker compose -f docker-compose-build.yaml up
+# use images built from local sources
+docker compose -f docker-compose-build-nf.yaml up
 # use images from docker hub
 docker compose up # add -d to run in background mode
 ```

--- a/base/Dockerfile.base-slim
+++ b/base/Dockerfile.base-slim
@@ -1,0 +1,21 @@
+#
+# Dockerfile responsible to create only the base image without building free5gc sources
+#
+
+FROM golang:1.14.4-stretch AS builder
+
+LABEL maintainer="Free5GC <support@free5gc.org>"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install dependencies
+RUN apt-get update \
+    && apt-get -y install gcc cmake autoconf libtool pkg-config libmnl-dev libyaml-dev apt-transport-https ca-certificates \
+    && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update \
+    && apt-get install -y nodejs yarn
+
+# Clean apt cache
+RUN apt-get clean

--- a/base/Dockerfile.base-slim.nf
+++ b/base/Dockerfile.base-slim.nf
@@ -1,0 +1,34 @@
+#
+# Dockerfile responsible to build a specific free5gc NF from the sources located at
+# the host
+#
+# Prior to this build invocation you must clone free5gc sources into this folder (i.e.
+# 'base') on the host
+# E.g.:
+# git clone --recursive -b v3.2.1 -j `nproc` https://github.com/free5gc/free5gc.git
+
+FROM free5gc/base-slim as my-base
+
+ENV DEBIAN_FRONTEND noninteractive
+ARG F5GC_MODULE
+
+# Get Free5GC
+COPY free5gc/ $GOPATH/src/free5gc/
+
+RUN cd $GOPATH/src/free5gc \
+    && make ${F5GC_MODULE}
+
+# Alpine is used for debug purpose. You can use scratch for a smaller footprint.
+FROM alpine:3.15
+
+WORKDIR /free5gc
+RUN mkdir -p config/TLS/ public
+
+# Copy executables
+COPY --from=my-base /go/src/free5gc/bin/${F5GC_MODULE} ./
+
+# Copy configuration files (not used for now)
+COPY --from=my-base /go/src/free5gc/config/* ./config/
+
+# Copy default certificates (not used for now)
+COPY --from=my-base /go/src/free5gc/config/TLS/* ./config/TLS/

--- a/base/Dockerfile.base-slim.webconsole
+++ b/base/Dockerfile.base-slim.webconsole
@@ -1,0 +1,27 @@
+FROM free5gc/base-slim as my-base
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Get Free5GC
+COPY free5gc/ $GOPATH/src/free5gc/
+
+RUN cd $GOPATH/src/free5gc \
+    && make webconsole
+
+# Alpine is used for debug purpose. You can use scratch for a smaller footprint.
+FROM alpine:3.15
+
+WORKDIR /free5gc
+RUN mkdir -p config/TLS/ public
+
+# Copy executables
+COPY --from=my-base /go/src/free5gc/webconsole/bin/webconsole ./webui
+
+# Copy static files (webui frontend)
+COPY --from=my-base /go/src/free5gc/webconsole/public ./public
+
+# Copy configuration files (not used for now)
+COPY --from=my-base /go/src/free5gc/config/* ./config/
+
+# Copy default certificates (not used for now)
+COPY --from=my-base /go/src/free5gc/config/TLS/* ./config/TLS/

--- a/docker-compose-build-nf.yaml
+++ b/docker-compose-build-nf.yaml
@@ -1,0 +1,284 @@
+version: '3.8'
+
+services:
+  free5gc-upf:
+    container_name: upf
+    build:
+      context: ./nf_upf
+      dockerfile: Dockerfile.nf
+      args:
+        DEBUG_TOOLS: "false"
+    command: bash -c "./upf-iptables.sh && ./upf -c ./config/upfcfg.yaml"
+    volumes:
+      - ./config/upfcfg.yaml:/free5gc/config/upfcfg.yaml
+      - ./config/upf-iptables.sh:/free5gc/upf-iptables.sh
+    cap_add:
+      - NET_ADMIN
+    networks:
+      privnet:
+        aliases:
+          - upf.free5gc.org
+
+  db:
+    container_name: mongodb
+    image: mongo
+    command: mongod --port 27017
+    expose:
+      - "27017"
+    volumes:
+      - dbdata:/data/db
+    networks:
+      privnet:
+        aliases:
+          - db
+
+  free5gc-nrf:
+    container_name: nrf
+    build:
+      context: ./nf_nrf
+      dockerfile: Dockerfile.nf
+      args:
+        DEBUG_TOOLS: "false"
+    command: ./nrf -c ./config/nrfcfg.yaml
+    expose:
+      - "8000"
+    volumes:
+      - ./config/nrfcfg.yaml:/free5gc/config/nrfcfg.yaml
+    environment:
+      DB_URI: mongodb://db/free5gc
+      GIN_MODE: release
+    networks:
+      privnet:
+        aliases:
+          - nrf.free5gc.org
+    depends_on:
+      - db
+
+  free5gc-amf:
+    container_name: amf
+    build:
+      context: ./nf_amf
+      dockerfile: Dockerfile.nf
+      args:
+        DEBUG_TOOLS: "false"
+    command: ./amf -c ./config/amfcfg.yaml
+    expose:
+      - "8000"
+    volumes:
+      - ./config/amfcfg.yaml:/free5gc/config/amfcfg.yaml
+    environment:
+      GIN_MODE: release
+    networks:
+      privnet:
+        aliases:
+          - amf.free5gc.org
+    depends_on:
+      - free5gc-nrf
+
+  free5gc-ausf:
+    container_name: ausf
+    build:
+      context: ./nf_ausf
+      dockerfile: Dockerfile.nf
+      args:
+        DEBUG_TOOLS: "false"
+    command: ./ausf -c ./config/ausfcfg.yaml
+    expose:
+      - "8000"
+    volumes:
+      - ./config/ausfcfg.yaml:/free5gc/config/ausfcfg.yaml
+    environment:
+      GIN_MODE: release
+    networks:
+      privnet:
+        aliases:
+          - ausf.free5gc.org
+    depends_on:
+      - free5gc-nrf
+
+  free5gc-nssf:
+    container_name: nssf
+    build:
+      context: ./nf_nssf
+      dockerfile: Dockerfile.nf
+      args:
+        DEBUG_TOOLS: "false"
+    command: ./nssf -c ./config/nssfcfg.yaml
+    expose:
+      - "8000"
+    volumes:
+      - ./config/nssfcfg.yaml:/free5gc/config/nssfcfg.yaml
+    environment:
+      GIN_MODE: release
+    networks:
+      privnet:
+        aliases:
+          - nssf.free5gc.org
+    depends_on:
+      - free5gc-nrf
+
+  free5gc-pcf:
+    container_name: pcf
+    build:
+      context: ./nf_pcf
+      dockerfile: Dockerfile.nf
+      args:
+        DEBUG_TOOLS: "false"
+    command: ./pcf -c ./config/pcfcfg.yaml
+    expose:
+      - "8000"
+    volumes:
+      - ./config/pcfcfg.yaml:/free5gc/config/pcfcfg.yaml
+    environment:
+      GIN_MODE: release
+    networks:
+      privnet:
+        aliases:
+          - pcf.free5gc.org
+    depends_on:
+      - free5gc-nrf
+
+  free5gc-smf:
+    container_name: smf
+    build:
+      context: ./nf_smf
+      dockerfile: Dockerfile.nf
+      args:
+        DEBUG_TOOLS: "false"
+    command: ./smf -c ./config/smfcfg.yaml -u ./config/uerouting.yaml
+    expose:
+      - "8000"
+    volumes:
+      - ./config/smfcfg.yaml:/free5gc/config/smfcfg.yaml
+      - ./config/uerouting.yaml:/free5gc/config/uerouting.yaml
+    environment:
+      GIN_MODE: release
+    networks:
+      privnet:
+        aliases:
+          - smf.free5gc.org
+    depends_on:
+      - free5gc-nrf
+      - free5gc-upf
+
+  free5gc-udm:
+    container_name: udm
+    build:
+      context: ./nf_udm
+      dockerfile: Dockerfile.nf
+      args:
+        DEBUG_TOOLS: "false"
+    command: ./udm -c ./config/udmcfg.yaml
+    expose:
+      - "8000"
+    volumes:
+      - ./config/udmcfg.yaml:/free5gc/config/udmcfg.yaml
+    environment:
+      GIN_MODE: release
+    networks:
+      privnet:
+        aliases:
+          - udm.free5gc.org
+    depends_on:
+      - db
+      - free5gc-nrf
+
+  free5gc-udr:
+    container_name: udr
+    build:
+      context: ./nf_udr
+      dockerfile: Dockerfile.nf
+      args:
+        DEBUG_TOOLS: "false"
+    command: ./udr -c ./config/udrcfg.yaml
+    expose:
+      - "8000"
+    volumes:
+      - ./config/udrcfg.yaml:/free5gc/config/udrcfg.yaml
+    environment:
+      DB_URI: mongodb://db/free5gc
+      GIN_MODE: release
+    networks:
+      privnet:
+        aliases:
+          - udr.free5gc.org
+    depends_on:
+      - db
+      - free5gc-nrf
+
+  free5gc-n3iwf:
+    container_name: n3iwf
+    build:
+      context: ./nf_n3iwf
+      dockerfile: Dockerfile.nf
+      args:
+        DEBUG_TOOLS: "false"
+    command: sh -c "./n3iwf-ipsec.sh && ./n3iwf -c ./config/n3iwfcfg.yaml"
+    volumes:
+      - ./config/n3iwfcfg.yaml:/free5gc/config/n3iwfcfg.yaml
+      - ./config/n3iwf-ipsec.sh:/free5gc/n3iwf-ipsec.sh
+    environment:
+      GIN_MODE: release
+    cap_add:
+      - NET_ADMIN
+    networks:
+      privnet:
+        aliases:
+          - n3iwf.free5gc.org
+    depends_on:
+      - free5gc-amf
+      - free5gc-smf
+      - free5gc-upf
+
+  free5gc-webui:
+    container_name: webui
+    build:
+      context: ./webui
+      dockerfile: Dockerfile.nf
+      args:
+        DEBUG_TOOLS: "false"
+    command: ./webui -c ./config/webuicfg.yaml
+    volumes:
+      - ./config/webuicfg.yaml:/free5gc/config/webuicfg.yaml
+    environment:
+      - GIN_MODE=release
+    networks:
+      privnet:
+        aliases:
+          - webui
+    ports:
+      - "5000:5000"
+    depends_on:
+      - db
+
+  ueransim:
+    container_name: ueransim
+    build:
+      context: ./ueransim
+    command: ./nr-gnb -c ./config/gnbcfg.yaml
+    volumes:
+      - ./config/gnbcfg.yaml:/ueransim/config/gnbcfg.yaml
+      - ./config/uecfg.yaml:/ueransim/config/uecfg.yaml
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - "/dev/net/tun"
+    networks:
+      privnet:
+        aliases:
+          - gnb.free5gc.org
+    depends_on:
+      - free5gc-amf
+      - free5gc-upf
+
+networks:
+  privnet:
+    ipam:
+      driver: default
+      config:
+        - subnet: 10.100.200.0/24
+    driver_opts:
+      com.docker.network.bridge.name: br-free5gc
+
+volumes:
+  dbdata:

--- a/nf_amf/Dockerfile.nf
+++ b/nf_amf/Dockerfile.nf
@@ -1,0 +1,29 @@
+FROM free5gc/amf-base:latest AS builder
+FROM alpine:3.15
+
+LABEL description="Free5GC open source 5G Core Network" \
+    version="Stage 3"
+
+ENV F5GC_MODULE amf
+ARG DEBUG_TOOLS
+
+# Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
+
+# Set working dir
+WORKDIR /free5gc
+RUN mkdir -p config/ log/ config/TLS/
+
+# Copy executable and default certs
+COPY --from=builder /free5gc/${F5GC_MODULE} ./
+COPY --from=builder /free5gc/config/TLS/${F5GC_MODULE}.pem ./config/TLS/
+COPY --from=builder /free5gc/config/TLS/${F5GC_MODULE}.key ./config/TLS/
+
+# Config files volume
+VOLUME [ "/free5gc/config" ]
+
+# Certificates (if not using default) volume
+VOLUME [ "/free5gc/config/TLS" ]
+
+# Exposed ports
+EXPOSE 8000

--- a/nf_ausf/Dockerfile.nf
+++ b/nf_ausf/Dockerfile.nf
@@ -1,0 +1,29 @@
+FROM free5gc/ausf-base:latest AS builder
+FROM alpine:3.15
+
+LABEL description="Free5GC open source 5G Core Network" \
+    version="Stage 3"
+
+ENV F5GC_MODULE ausf
+ARG DEBUG_TOOLS
+
+# Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
+
+# Set working dir
+WORKDIR /free5gc
+RUN mkdir -p config/ log/ config/TLS/
+
+# Copy executable and default certs
+COPY --from=builder /free5gc/${F5GC_MODULE} ./
+COPY --from=builder /free5gc/config/TLS/${F5GC_MODULE}.pem ./config/TLS/
+COPY --from=builder /free5gc/config/TLS/${F5GC_MODULE}.key ./config/TLS/
+
+# Config files volume
+VOLUME [ "/free5gc/config" ]
+
+# Certificates (if not using default) volume
+VOLUME [ "/free5gc/config/TLS" ]
+
+# Exposed ports
+EXPOSE 8000

--- a/nf_n3iwf/Dockerfile.nf
+++ b/nf_n3iwf/Dockerfile.nf
@@ -1,0 +1,29 @@
+FROM free5gc/n3iwf-base:latest AS builder
+FROM alpine:3.15
+
+LABEL description="Free5GC open source 5G Core Network" \
+    version="Stage 3"
+
+ENV F5GC_MODULE n3iwf
+ARG DEBUG_TOOLS
+
+# Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
+
+# Install N3IWF dependencies
+RUN apk add -U iproute2
+
+# Set working dir
+WORKDIR /free5gc
+RUN mkdir -p config/ log/ config/TLS/
+
+# Copy executable and default certs
+COPY --from=builder /free5gc/${F5GC_MODULE} ./
+COPY --from=builder /free5gc/config/TLS/${F5GC_MODULE}.pem ./config/TLS/
+COPY --from=builder /free5gc/config/TLS/${F5GC_MODULE}.key ./config/TLS/
+
+# Config files volume
+VOLUME [ "/free5gc/config" ]
+
+# Certificates (if not using default) volume
+VOLUME [ "/free5gc/config/TLS" ]

--- a/nf_nrf/Dockerfile.nf
+++ b/nf_nrf/Dockerfile.nf
@@ -1,0 +1,29 @@
+FROM free5gc/nrf-base:latest AS builder
+FROM alpine:3.15
+
+LABEL description="Free5GC open source 5G Core Network" \
+    version="Stage 3"
+
+ENV F5GC_MODULE nrf
+ARG DEBUG_TOOLS
+
+# Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
+
+# Set working dir
+WORKDIR /free5gc
+RUN mkdir -p config/ log/ config/TLS/
+
+# Copy executable and default certs
+COPY --from=builder /free5gc/${F5GC_MODULE} ./
+COPY --from=builder /free5gc/config/TLS/${F5GC_MODULE}.pem ./config/TLS/
+COPY --from=builder /free5gc/config/TLS/${F5GC_MODULE}.key ./config/TLS/
+
+# Config files volume
+VOLUME [ "/free5gc/config" ]
+
+# Certificates (if not using default) volume
+VOLUME [ "/free5gc/config/TLS" ]
+
+# Exposed ports
+EXPOSE 8000

--- a/nf_nssf/Dockerfile.nf
+++ b/nf_nssf/Dockerfile.nf
@@ -1,0 +1,29 @@
+FROM free5gc/nssf-base:latest AS builder
+FROM alpine:3.15
+
+LABEL description="Free5GC open source 5G Core Network" \
+    version="Stage 3"
+
+ENV F5GC_MODULE nssf
+ARG DEBUG_TOOLS
+
+# Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
+
+# Set working dir
+WORKDIR /free5gc
+RUN mkdir -p config/ log/ config/TLS/
+
+# Copy executable and default certs
+COPY --from=builder /free5gc/${F5GC_MODULE} ./
+COPY --from=builder /free5gc/config/TLS/${F5GC_MODULE}.pem ./config/TLS/
+COPY --from=builder /free5gc/config/TLS/${F5GC_MODULE}.key ./config/TLS/
+
+# Config files volume
+VOLUME [ "/free5gc/config" ]
+
+# Certificates (if not using default) volume
+VOLUME [ "/free5gc/config/TLS" ]
+
+# Exposed ports
+EXPOSE 8000

--- a/nf_pcf/Dockerfile.nf
+++ b/nf_pcf/Dockerfile.nf
@@ -1,0 +1,29 @@
+FROM free5gc/pcf-base:latest AS builder
+FROM alpine:3.15
+
+LABEL description="Free5GC open source 5G Core Network" \
+    version="Stage 3"
+
+ENV F5GC_MODULE pcf
+ARG DEBUG_TOOLS
+
+# Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
+
+# Set working dir
+WORKDIR /free5gc
+RUN mkdir -p config/ log/ config/TLS/
+
+# Copy executable and default certs
+COPY --from=builder /free5gc/${F5GC_MODULE} ./
+COPY --from=builder /free5gc/config/TLS/${F5GC_MODULE}.pem ./config/TLS/
+COPY --from=builder /free5gc/config/TLS/${F5GC_MODULE}.key ./config/TLS/
+
+# Config files volume
+VOLUME [ "/free5gc/config" ]
+
+# Certificates (if not using default) volume
+VOLUME [ "/free5gc/config/TLS" ]
+
+# Exposed ports
+EXPOSE 8000

--- a/nf_smf/Dockerfile.nf
+++ b/nf_smf/Dockerfile.nf
@@ -1,0 +1,29 @@
+FROM free5gc/smf-base:latest AS builder
+FROM alpine:3.15
+
+LABEL description="Free5GC open source 5G Core Network" \
+    version="Stage 3"
+
+ENV F5GC_MODULE smf
+ARG DEBUG_TOOLS
+
+# Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
+
+# Set working dir
+WORKDIR /free5gc
+RUN mkdir -p config/ log/ config/TLS/
+
+# Copy executable and default certs
+COPY --from=builder /free5gc/${F5GC_MODULE} ./
+COPY --from=builder /free5gc/config/TLS/${F5GC_MODULE}.pem ./config/TLS/
+COPY --from=builder /free5gc/config/TLS/${F5GC_MODULE}.key ./config/TLS/
+
+# Config files volume
+VOLUME [ "/free5gc/config" ]
+
+# Certificates (if not using default) volume
+VOLUME [ "/free5gc/config/TLS" ]
+
+# Exposed ports
+EXPOSE 8000

--- a/nf_udm/Dockerfile.nf
+++ b/nf_udm/Dockerfile.nf
@@ -1,0 +1,29 @@
+FROM free5gc/udm-base:latest AS builder
+FROM alpine:3.15
+
+LABEL description="Free5GC open source 5G Core Network" \
+    version="Stage 3"
+
+ENV F5GC_MODULE udm
+ARG DEBUG_TOOLS
+
+# Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
+
+# Set working dir
+WORKDIR /free5gc
+RUN mkdir -p config/ log/ config/TLS/
+
+# Copy executable and default certs
+COPY --from=builder /free5gc/${F5GC_MODULE} ./
+COPY --from=builder /free5gc/config/TLS/${F5GC_MODULE}.pem ./config/TLS/
+COPY --from=builder /free5gc/config/TLS/${F5GC_MODULE}.key ./config/TLS/
+
+# Config files volume
+VOLUME [ "/free5gc/config" ]
+
+# Certificates (if not using default) volume
+VOLUME [ "/free5gc/config/TLS" ]
+
+# Exposed ports
+EXPOSE 8000

--- a/nf_udr/Dockerfile.nf
+++ b/nf_udr/Dockerfile.nf
@@ -1,0 +1,29 @@
+FROM free5gc/udr-base:latest AS builder
+FROM alpine:3.15
+
+LABEL description="Free5GC open source 5G Core Network" \
+    version="Stage 3"
+
+ENV F5GC_MODULE udr
+ARG DEBUG_TOOLS
+
+# Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apk add -U vim strace net-tools curl netcat-openbsd ; fi
+
+# Set working dir
+WORKDIR /free5gc
+RUN mkdir -p config/ log/ config/TLS/
+
+# Copy executable and default certs
+COPY --from=builder /free5gc/${F5GC_MODULE} ./
+COPY --from=builder /free5gc/config/TLS/${F5GC_MODULE}.pem ./config/TLS/
+COPY --from=builder /free5gc/config/TLS/${F5GC_MODULE}.key ./config/TLS/
+
+# Config files volume
+VOLUME [ "/free5gc/config" ]
+
+# Certificates (if not using default) volume
+VOLUME [ "/free5gc/config/TLS" ]
+
+# Exposed ports
+EXPOSE 8000

--- a/nf_upf/Dockerfile.nf
+++ b/nf_upf/Dockerfile.nf
@@ -1,0 +1,27 @@
+FROM free5gc/upf-base:latest AS builder
+FROM bitnami/minideb:bullseye
+
+LABEL description="Free5GC open source 5G Core Network" \
+    version="Stage 3"
+
+ENV F5GC_MODULE upf
+ENV DEBIAN_FRONTEND noninteractive
+ARG DEBUG_TOOLS
+
+# Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apt-get update && apt-get install -y vim strace net-tools iputils-ping curl netcat ; fi
+
+# Install UPF dependencies
+RUN apt-get update \
+    && apt-get install -y libmnl0 libyaml-0-2 iproute2 iptables \
+    && apt-get clean
+
+# Set working dir
+WORKDIR /free5gc
+RUN mkdir -p config/ log/
+
+# Copy executable
+COPY --from=builder /free5gc/${F5GC_MODULE} ./
+
+# Config files volume
+VOLUME [ "/free5gc/config" ]

--- a/webui/Dockerfile.nf
+++ b/webui/Dockerfile.nf
@@ -1,0 +1,26 @@
+FROM free5gc/webconsole-base:latest AS builder
+FROM bitnami/minideb:bullseye
+
+LABEL description="Free5GC open source 5G Core Network" \
+    version="Stage 3"
+
+ENV F5GC_MODULE webui
+ENV DEBIAN_FRONTEND noninteractive
+ARG DEBUG_TOOLS
+
+# Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)
+RUN if [ "$DEBUG_TOOLS" = "true" ] ; then apt-get update && apt-get install -y vim strace net-tools curl netcat-openbsd ; fi
+
+# Set working dir
+WORKDIR /free5gc
+RUN mkdir -p config/ public/
+
+# Copy executable, frontend static files and default configuration
+COPY --from=builder /free5gc/${F5GC_MODULE} ./
+COPY --from=builder /free5gc/public ./public
+
+# Config files volume
+VOLUME [ "/free5gc/config" ]
+
+# WebUI uses the port 5000
+EXPOSE 5000


### PR DESCRIPTION
Hi,
It seems that the current version of free5gc-compose does not support building from free5gc sources located in the developer's host. I have updated free5gc-compose to support that.

This is very helpful for me as I can quickly test my local changes in the all-in-one docker compose environment.
