### PR TITLE
t3555 timer addition to amf configuration file to keep inline with free5gc

### DIFF
--- a/config/amfcfg.yaml
+++ b/config/amfcfg.yaml
@@ -90,6 +90,11 @@ configuration:
     enable: true     # true or false
     expireTime: 6s   # default is 6 seconds
     maxRetryTimes: 4 # the max number of retransmission
+  # retransmission timer for NAS Configuration Update Command message
+  t3555:
+    enable: true     # true or false
+    expireTime: 6s   # default is 6 seconds
+    maxRetryTimes: 4 # the max number of retransmission
   # retransmission timer for NAS Authentication Request/Security Mode Command message
   t3560:
     enable: true     # true or false


### PR DESCRIPTION
Add t3555 timer parameters to amf configuration file.
t3555 timer is present in the free5gc amf config file.
This commit keep amf config inline with free5gc amf config.