### PR TITLE
Fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ Please refer to the [wiki](https://github.com/free5gc/free5gc/wiki) for more tro
 
 The integration with the [UERANSIM](https://github.com/aligungr/UERANSIM) eNB/UE simulator is documented [here](https://free5gc.org/guide/5-install-ueransim/).
 
-You can also refer to this [issue](https://github.com/free5gc/free5gc-compose/issues/26) to find out how you can configure the UPF to forward traffic between the [UERANSIM](https://github.com/aligungr/UERANSIM) to the DN (eg. internet) in a docker environment.
-
 This [issue](https://github.com/free5gc/free5gc-compose/issues/28) provides detailed steps that might be useful.
 
 ### srsRAN Notes

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Please refer to the [wiki](https://github.com/free5gc/free5gc/wiki) for more tro
 
 ### UERANSIM Notes
 
-The integration with the [UERANSIM](https://github.com/aligungr/UERANSIM) eNB/UE simulator is documented [here](https://www.free5gc.org/installations/stage-3-sim-install/). 
+The integration with the [UERANSIM](https://github.com/aligungr/UERANSIM) eNB/UE simulator is documented [here](https://free5gc.org/guide/5-install-ueransim/).
 
 You can also refer to this [issue](https://github.com/free5gc/free5gc-compose/issues/26) to find out how you can configure the UPF to forward traffic between the [UERANSIM](https://github.com/aligungr/UERANSIM) to the DN (eg. internet) in a docker environment.
 


### PR DESCRIPTION
Hi!

I was trying to run free5c here and I found out that the link for integration with UERASIM was broken. I found the original in Wayback Machine, and then I found that it still exists under the URL https://free5gc.org/guide/5-install-ueransim/ . I also noticed that the code provided in the issue referenced at the "UERANSIM Notes" is already merged on the main code.

This PR does this:
- 5a73a06cfe600eddad5fc1384a3a19d29db654b6: fix UERASIM install guide link, replacing it by the newer one
- e72f93554a7bd2ed14a1714fdc97e922bb90e6c9: remove reference to the issue #26 as its code was merged in 4fac16e72dc272067c9b220576dcb716c6e46bdb