### PR TITLE
feat: bump webui to v3.4

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -213,7 +213,7 @@ services:
 
   free5gc-webui:
     container_name: webui
-    image: free5gc/webui:v3.3.0
+    image: free5gc/webui:v3.4.0
     command: ./webui -c ./config/webuicfg.yaml
     expose:
       - "2122"


### PR DESCRIPTION
This PR changes the version of `free5c-webui` on docker-compose, as it is the latest version (https://hub.docker.com/r/free5gc/webui/tags).

With the current version (`v3.3.0`), `free5gc-webui` won't run, as the `info.version` on `config/webuicfg.yaml` is `1.0.2` (expected by `v3.4.0` but not by `v3.3.0`, change introduced on 14d6c059). This screenshot shows it:

![webui](https://github.com/free5gc/free5gc-compose/assets/12701580/f5a0e91f-3559-4f9e-b42a-bb5785e836a0)

This error doesn't happen with the latest version of `free5gc-webui`,
