### PR TITLE
fix: use mongosh instead of mongo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ docker compose rm
 Sometimes, you need to drop data from DB:
 
 ```bash
-docker exec -it mongodb mongo
+docker exec -it mongodb mongosh
 > use free5gc
 > db.dropDatabase()
 > exit # (Or Ctrl-D)


### PR DESCRIPTION
Hi!

This PR changes `mongo` by `mongosh` on README, as the mongo shell is invoked with `mongosh` on newer versions and `docker exec -it mongodb mongo` won't take effect.