### PR TITLE
feat: run nr-ue on UERANSIM

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Please refer to the [wiki](https://github.com/free5gc/free5gc/wiki) for more tro
 
 The integration with the [UERANSIM](https://github.com/aligungr/UERANSIM) eNB/UE simulator is documented [here](https://free5gc.org/guide/5-install-ueransim/).
 
+In order to run UERASIM, make sure you have a subscriber. Follow the steps [here](https://free5gc.org/guide/Webconsole/Create-Subscriber-via-webconsole/#4-open-webconsole). Make sure that the field `supi` field on `config/uecfg.yaml` has the same value as the `UE ID` of the subscriber you have just created. If they differ, change the `supi` field value by the one from the `UE ID`.
+
 This [issue](https://github.com/free5gc/free5gc-compose/issues/28) provides detailed steps that might be useful.
 
 ### srsRAN Notes

--- a/config/nr-gnb-ue.sh
+++ b/config/nr-gnb-ue.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./nr-gnb -c ./config/gnbcfg.yaml & ./nr-ue -c config/uecfg.yaml

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -213,7 +213,7 @@ services:
 
   free5gc-webui:
     container_name: webui
-    image: free5gc/webui:v3.3.0
+    image: free5gc/webui:v3.4.0
     command: ./webui -c ./config/webuicfg.yaml
     expose:
       - "2122"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -236,10 +236,11 @@ services:
   ueransim:
     container_name: ueransim
     image: free5gc/ueransim:latest
-    command: ./nr-gnb -c ./config/gnbcfg.yaml
+    command: ./nr-gnb-ue.sh
     volumes:
       - ./config/gnbcfg.yaml:/ueransim/config/gnbcfg.yaml
       - ./config/uecfg.yaml:/ueransim/config/uecfg.yaml
+      - ./config/nr-gnb-ue.sh:/ueransim/nr-gnb-ue.sh
     cap_add:
       - NET_ADMIN
     devices:


### PR DESCRIPTION
Hi (again)!

Currently, only `./nr-gnb` is runned on `ueransim` container, so, it doesn't create the new network interfaces:

![Screenshot_20240319_122905](https://github.com/free5gc/free5gc-compose/assets/12701580/b2816a0c-4758-4946-b3fa-2300ed9ee090)

This PR introduces a new script, `config/nr-gnb-ue.sh`, that runs both `nr-gnb` and `/nr-ue`.

- e36d6ffcc1b09c4c85ea1eae946fae4612d8f8d2: this commit adds the new script and changes `docker-compose.yml` to run that instead of only running `nr-gnb`
- bbb8bef7f71d96712409204737a98cb627824296: this commit updates the README with instructions for creating a subscriber and using its UE ID on UERANSIM