### PR TITLE
feat: upgrade to version 3.4.1

### DIFF
--- a/docker-compose-build.yaml
+++ b/docker-compose-build.yaml
@@ -266,6 +266,7 @@ services:
       - "5000:5000"
     depends_on:
       - db
+      - free5gc-nrf
 
   ueransim:
     container_name: ueransim

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   free5gc-upf:
     container_name: upf
-    image: free5gc/upf:v3.3.0
+    image: free5gc/upf:v3.4.1
     command: bash -c "./upf-iptables.sh && ./upf -c ./config/upfcfg.yaml"
     volumes:
       - ./config/upfcfg.yaml:/free5gc/config/upfcfg.yaml
@@ -30,7 +30,7 @@ services:
 
   free5gc-nrf:
     container_name: nrf
-    image: free5gc/nrf:v3.3.0
+    image: free5gc/nrf:v3.4.1
     command: ./nrf -c ./config/nrfcfg.yaml
     expose:
       - "8000"
@@ -48,7 +48,7 @@ services:
 
   free5gc-amf:
     container_name: amf
-    image: free5gc/amf:v3.3.0
+    image: free5gc/amf:v3.4.1
     command: ./amf -c ./config/amfcfg.yaml
     expose:
       - "8000"
@@ -65,7 +65,7 @@ services:
 
   free5gc-ausf:
     container_name: ausf
-    image: free5gc/ausf:v3.3.0
+    image: free5gc/ausf:v3.4.1
     command: ./ausf -c ./config/ausfcfg.yaml
     expose:
       - "8000"
@@ -82,7 +82,7 @@ services:
 
   free5gc-nssf:
     container_name: nssf
-    image: free5gc/nssf:v3.3.0
+    image: free5gc/nssf:v3.4.1
     command: ./nssf -c ./config/nssfcfg.yaml
     expose:
       - "8000"
@@ -99,7 +99,7 @@ services:
 
   free5gc-pcf:
     container_name: pcf
-    image: free5gc/pcf:v3.3.0
+    image: free5gc/pcf:v3.4.1
     command: ./pcf -c ./config/pcfcfg.yaml
     expose:
       - "8000"
@@ -116,7 +116,7 @@ services:
 
   free5gc-smf:
     container_name: smf
-    image: free5gc/smf:v3.3.0
+    image: free5gc/smf:v3.4.1
     command: ./smf -c ./config/smfcfg.yaml -u ./config/uerouting.yaml
     expose:
       - "8000"
@@ -135,7 +135,7 @@ services:
 
   free5gc-udm:
     container_name: udm
-    image: free5gc/udm:v3.3.0
+    image: free5gc/udm:v3.4.1
     command: ./udm -c ./config/udmcfg.yaml
     expose:
       - "8000"
@@ -153,7 +153,7 @@ services:
 
   free5gc-udr:
     container_name: udr
-    image: free5gc/udr:v3.3.0
+    image: free5gc/udr:v3.4.1
     command: ./udr -c ./config/udrcfg.yaml
     expose:
       - "8000"
@@ -172,7 +172,7 @@ services:
 
   free5gc-chf:
     container_name: chf
-    image: free5gc/chf@sha256:8b29aeab340b41e67b566765980d86b291593a26d6d21a38903c8f4d7e1e9677
+    image: free5gc/chf@v3.4.1
     command: ./chf -c ./config/chfcfg.yaml
     expose:
       - "8000"
@@ -192,7 +192,7 @@ services:
 
   free5gc-n3iwf:
     container_name: n3iwf
-    image: free5gc/n3iwf:v3.3.0
+    image: free5gc/n3iwf:v3.4.1
     command: sh -c "./n3iwf-ipsec.sh && ./n3iwf -c ./config/n3iwfcfg.yaml"
     volumes:
       - ./config/n3iwfcfg.yaml:/free5gc/config/n3iwfcfg.yaml
@@ -213,7 +213,7 @@ services:
 
   free5gc-webui:
     container_name: webui
-    image: free5gc/webui:v3.3.0
+    image: free5gc/webui:v3.4.1
     command: ./webui -c ./config/webuicfg.yaml
     expose:
       - "2122"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -172,7 +172,7 @@ services:
 
   free5gc-chf:
     container_name: chf
-    image: free5gc/chf@v3.4.1
+    image: free5gc/chf:v3.4.1
     command: ./chf -c ./config/chfcfg.yaml
     expose:
       - "8000"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -232,6 +232,7 @@ services:
       - "2121:2121"
     depends_on:
       - db
+      - free5gc-nrf
 
   ueransim:
     container_name: ueransim


### PR DESCRIPTION
## Description 

Since https://github.com/free5gc/webconsole/pull/78, the webconsole would register to NRF as AF, so it's better to depend on NRF. 

## TODO
- [x] WebUI depend on NRF
- [x] v3.3.0 -> v3.4.0 (v3.4.1, Support Charging)  