### PR TITLE
Add instructions for running an UE

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,34 @@ The integration with the [UERANSIM](https://github.com/aligungr/UERANSIM) eNB/UE
 
 This [issue](https://github.com/free5gc/free5gc-compose/issues/28) provides detailed steps that might be useful.
 
+By default, the provided UERANSIM service on this `docker-compose.yaml` will only act as a gNB. If you want to create a UE you'll need to:
+
+1. Create a subscriber through the WebUI. Follow the steps [here](https://free5gc.org/guide/Webconsole/Create-Subscriber-via-webconsole/#4-open-webconsole)
+2. Copy the `UE ID` field
+3. Change the value of `supi` on `config/uecfg.yaml` to the UE ID that you just copied
+4. Add an UE service on `docker-compose.yaml` as it follows:
+
+~~~yaml
+  ue:
+    container_name: ue
+    image: free5gc/ueransim:latest
+    command: ./nr-ue -c ./config/uecfg.yaml
+    volumes:
+      - ./config/uecfg.yaml:/ueransim/config/uecfg.yaml
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - "/dev/net/tun"
+    networks:
+      privnet:
+        aliases:
+          - ue.free5gc.org
+    depends_on:
+      - ueransim
+~~~
+
+5. Run `docker-compose.yaml`
+
 ### srsRAN Notes
 
 You can check this [issue](https://github.com/free5gc/free5gc-compose/issues/94) for some sample configuration files of srsRAN + free5GC


### PR DESCRIPTION
This PR updates the REAMED with instructions for adding a service acting as a UE using UERANSIM, as the current `ueransim` service only acts as a gNB.