### PR TITLE
feat: add ULCL config folder and compose yaml compliant with free5gc v3.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,13 @@ For Linux kernel version below 5.4 you can setup a working environment using a v
 Please refer to [GTP5G kernel module](https://github.com/free5gc/gtp5g) for more information.
 
 ## ULCL Configuration 
-You can check the following informations below:
-- [ulcl-example branch](https://github.com/free5gc/free5gc-compose/tree/ulcl-example), or
-- [patch file](https://github.com/ianchen0119/free5gc-compose-ulcl)
+To start the core with a i-UPF and two PSA UPFs ULCL configuration, use
+
+```bash
+docker compose -f docker-compose-ulcl.yaml up
+```
+
+Check out the used configuration files at `config/ULCL`.
 
 ## Reference
 - https://github.com/open5gs/nextepc/tree/master/docker

--- a/config/ULCL/smfcfg.yaml
+++ b/config/ULCL/smfcfg.yaml
@@ -1,0 +1,123 @@
+info:
+  version: 1.0.7
+  description: SMF initial local configuration
+
+configuration:
+  smfName: SMF # the name of this SMF
+  sbi: # Service-based interface information
+    scheme: http # the protocol for sbi (http or https)
+    registerIPv4: smf.free5gc.org # IP used to register to NRF
+    bindingIPv4: smf.free5gc.org # IP used to bind the service
+    port: 8000 # Port used to bind the service
+    tls: # the local path of TLS key
+      key: cert/smf.key # SMF TLS Certificate
+      pem: cert/smf.pem # SMF TLS Private key
+  serviceNameList: # the SBI services provided by this SMF, refer to TS 29.502
+    - nsmf-pdusession # Nsmf_PDUSession service
+    - nsmf-event-exposure # Nsmf_EventExposure service
+    - nsmf-oam # OAM service
+  snssaiInfos: # the S-NSSAI (Single Network Slice Selection Assistance Information) list supported by this AMF
+    - sNssai: # S-NSSAI (Single Network Slice Selection Assistance Information)
+        sst: 1 # Slice/Service Type (uinteger, range: 0~255)
+        sd: 010203 # Slice Differentiator (3 bytes hex string, range: 000000~FFFFFF)
+      dnnInfos: # DNN information list
+        - dnn: internet # Data Network Name
+          dns: # the IP address of DNS
+            ipv4: 8.8.8.8
+            ipv6: 2001:4860:4860::8888
+  plmnList: # the list of PLMN IDs that this SMF belongs to (optional, remove this key when unnecessary)
+    - mcc: 208 # Mobile Country Code (3 digits string, digit: 0~9)
+      mnc: 93 # Mobile Network Code (2 or 3 digits string, digit: 0~9)
+  locality: area1 # Name of the location where a set of AMF, SMF, PCF and UPFs are located
+  pfcp: # the IP address of N4 interface on this SMF (PFCP)
+    # addr config is deprecated in smf config v1.0.3, please use the following config
+    nodeID: smf.free5gc.org # the Node ID of this SMF
+    listenAddr: smf.free5gc.org # the IP/FQDN of N4 interface on this SMF (PFCP)
+    externalAddr: smf.free5gc.org # the IP/FQDN of N4 interface on this SMF (PFCP)
+    heartbeatInterval: 5s
+  userplaneInformation: # list of userplane information
+    upNodes: # information of userplane node (AN or UPF)
+      gNB1: # the name of the node
+        type: AN # the type of the node (AN or UPF)
+        nodeID: gnb.free5gc.org # the Node ID of this gNB
+      i-UPF: # the name of the node
+        type: UPF # the type of the node (AN or UPF)
+        nodeID: i-upf.free5gc.org # the Node ID of this UPF
+        sNssaiUpfInfos: # S-NSSAI information list for this UPF
+          - sNssai: # S-NSSAI (Single Network Slice Selection Assistance Information)
+              sst: 1 # Slice/Service Type (uinteger, range: 0~255)
+              sd: 010203 # Slice Differentiator (3 bytes hex string, range: 000000~FFFFFF)
+            dnnUpfInfoList: # DNN information list for this S-NSSAI
+              - dnn: internet
+        interfaces: # Interface list for this UPF
+          - interfaceType: N3 # the type of the interface (N3 or N9)
+            endpoints: # the IP address of this N3/N9 interface on this UPF
+              - i-upf.free5gc.org
+            networkInstances: # Data Network Name (DNN)
+              - internet
+          - interfaceType: N9 # the type of the interface (N3 or N9)
+            endpoints: # the IP address of this N3/N9 interface on this UPF
+              - i-upf.free5gc.org
+            networkInstances: # Data Network Name (DNN)
+              - internet
+      UPF-1: # the name of the node
+        type: UPF # the type of the node (AN or UPF)
+        nodeID: upf-1.free5gc.org # the Node ID of this UPF
+        sNssaiUpfInfos: # S-NSSAI information list for this UPF
+          - sNssai: # S-NSSAI (Single Network Slice Selection Assistance Information)
+              sst: 1 # Slice/Service Type (uinteger, range: 0~255)
+              sd: 010203 # Slice Differentiator (3 bytes hex string, range: 000000~FFFFFF)
+            dnnUpfInfoList: # DNN information list for this S-NSSAI
+              - dnn: internet
+                pools:
+                  - cidr: 10.60.0.0/16
+        interfaces: # Interface list for this UPF
+          - interfaceType: N9 # the type of the interface (N3 or N9)
+            endpoints: # the IP address of this N3/N9 interface on this UPF
+              - upf-1.free5gc.org
+            networkInstances: # Data Network Name (DNN)
+              - internet
+      UPF-2: # the name of the node
+        type: UPF # the type of the node (AN or UPF)
+        nodeID: upf-2.free5gc.org # the Node ID of this UPF
+        sNssaiUpfInfos: # S-NSSAI information list for this UPF
+          - sNssai: # S-NSSAI (Single Network Slice Selection Assistance Information)
+              sst: 1 # Slice/Service Type (uinteger, range: 0~255)
+              sd: 010203 # Slice Differentiator (3 bytes hex string, range: 000000~FFFFFF)
+            dnnUpfInfoList: # DNN information list for this S-NSSAI
+              - dnn: internet
+                pools:
+                  - cidr: 10.61.0.1/32
+        interfaces: # Interface list for this UPF
+          - interfaceType: N9 # the type of the interface (N3 or N9)
+            endpoints: # the IP address of this N3/N9 interface on this UPF
+              - upf-2.free5gc.org
+            networkInstances: # Data Network Name (DNN)
+              - internet
+    links: # the topology graph of userplane, A and B represent the two nodes of each link
+      - A: gNB1
+        B: i-UPF
+      - A: i-UPF
+        B: UPF-1
+      - A: i-UPF
+        B: UPF-2
+  ulcl: true
+  # retransmission timer for pdu session modification command
+  t3591:
+    enable: true # true or false
+    expireTime: 16s # default is 6 seconds
+    maxRetryTimes: 3 # the max number of retransmission
+  # retransmission timer for pdu session release command
+  t3592:
+    enable: true # true or false
+    expireTime: 16s # default is 6 seconds
+    maxRetryTimes: 3 # the max number of retransmission
+  nrfUri: http://nrf.free5gc.org:8000 # a valid URI of NRF
+  nrfCertPem: cert/nrf.pem # NRF Certificate
+  urrPeriod: 10 # default usage report period in seconds
+  urrThreshold: 1000 # default usage report threshold in bytes
+  requestedUnit: 1000
+logger: # log output setting
+  enable: true # true or false
+  level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
+  reportCaller: false # enable the caller report or not, value: true or false

--- a/config/ULCL/uerouting.yaml
+++ b/config/ULCL/uerouting.yaml
@@ -1,0 +1,15 @@
+info:
+  version: 1.0.7
+  description: Routing information for UE
+
+ueRoutingInfo: # the list of UE routing information
+  UE1: # Group Name
+    members:
+    - imsi-208930000000001 # Subscription Permanent Identifier of the UE
+    topology: # Network topology for this group (Uplink: A->B, Downlink: B->A)
+    # default path derived from this topology
+    # node name should be consistent with smfcfg.yaml
+      - A: gNB1
+        B: i-UPF
+      - A: i-UPF
+        B: UPF-1

--- a/config/ULCL/upfcfg-1.yaml
+++ b/config/ULCL/upfcfg-1.yaml
@@ -1,0 +1,27 @@
+version: 1.0.3
+description: UPF initial local configuration
+
+# The listen IP and nodeID of the N4 interface on this UPF (Can't set to 0.0.0.0)
+pfcp:
+  addr: upf-1.free5gc.org # IP addr for listening
+  nodeID: upf-1.free5gc.org # External IP or FQDN can be reached
+  retransTimeout: 1s # retransmission timeout
+  maxRetrans: 3 # the max number of retransmission
+
+gtpu:
+  forwarder: gtp5g
+  # The IP list of the N3/N9 interfaces on this UPF
+  # If there are multiple connection, set addr to 0.0.0.0 or list all the addresses
+  ifList:
+    - addr: upf-1.free5gc.org
+      type: N9
+
+# The DNN list supported by UPF
+dnnList:
+  - dnn: internet # Data Network Name
+    cidr: 10.60.0.0/24 # Classless Inter-Domain Routing for assigned IPv4 pool of UE
+
+logger: # log output setting
+  enable: true # true or false
+  level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
+  reportCaller: false # enable the caller report or not, value: true or false

--- a/config/ULCL/upfcfg-2.yaml
+++ b/config/ULCL/upfcfg-2.yaml
@@ -1,0 +1,27 @@
+version: 1.0.3
+description: UPF initial local configuration
+
+# The listen IP and nodeID of the N4 interface on this UPF (Can't set to 0.0.0.0)
+pfcp:
+  addr: upf-2.free5gc.org # IP addr for listening
+  nodeID: upf-2.free5gc.org # External IP or FQDN can be reached
+  retransTimeout: 1s # retransmission timeout
+  maxRetrans: 3 # the max number of retransmission
+
+gtpu:
+  forwarder: gtp5g
+  # The IP list of the N3/N9 interfaces on this UPF
+  # If there are multiple connection, set addr to 0.0.0.0 or list all the addresses
+  ifList:
+    - addr: upf-2.free5gc.org
+      type: N9
+
+# The DNN list supported by UPF
+dnnList:
+  - dnn: internet # Data Network Name
+    cidr: 10.61.0.0/24 # Classless Inter-Domain Routing for assigned IPv4 pool of UE
+
+logger: # log output setting
+  enable: true # true or false
+  level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
+  reportCaller: false # enable the caller report or not, value: true or false

--- a/config/ULCL/upfcfg-i-upf.yaml
+++ b/config/ULCL/upfcfg-i-upf.yaml
@@ -1,0 +1,31 @@
+version: 1.0.3
+description: UPF initial local configuration
+
+# The listen IP and nodeID of the N4 interface on this UPF (Can't set to 0.0.0.0)
+pfcp:
+  addr: i-upf.free5gc.org # IP addr for listening
+  nodeID: i-upf.free5gc.org # External IP or FQDN can be reached
+  retransTimeout: 1s # retransmission timeout
+  maxRetrans: 3 # the max number of retransmission
+
+gtpu:
+  forwarder: gtp5g
+  # The IP list of the N3/N9 interfaces on this UPF
+  # If there are multiple connection, set addr to 0.0.0.0 or list all the addresses
+  ifList:
+    - addr: i-upf.free5gc.org
+      type: N3
+    - addr: i-upf.free5gc.org
+      type: N9
+
+# The DNN list supported by UPF
+dnnList:
+  - dnn: internet # Data Network Name
+    cidr: 10.60.0.0/24 # Classless Inter-Domain Routing for assigned IPv4 pool of UE
+  - dnn: internet # Data Network Name
+    cidr: 10.61.0.0/24 # Classless Inter-Domain Routing for assigned IPv4 pool of UE
+
+logger: # log output setting
+  enable: true # true or false
+  level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
+  reportCaller: false # enable the caller report or not, value: true or false

--- a/docker-compose-ulcl.yaml
+++ b/docker-compose-ulcl.yaml
@@ -1,0 +1,311 @@
+version: '3.8'
+
+services:
+  free5gc-i-upf:
+    container_name: i-upf
+    image: free5gc/upf:v3.4.1
+    command: bash -c "./upf-iptables.sh && ./upf -c ./config/upfcfg.yaml"
+    volumes:
+      - ./config/ULCL/upfcfg-i-upf.yaml:/free5gc/config/upfcfg.yaml
+      - ./config/upf-iptables.sh:/free5gc/upf-iptables.sh
+    cap_add:
+      - NET_ADMIN
+    networks:
+      privnet:
+        aliases:
+          - i-upf.free5gc.org
+
+  free5gc-upf-1:
+    container_name: upf-1
+    image: free5gc/upf:v3.4.1
+    command: bash -c "./upf-iptables.sh && ./upf -c ./config/upfcfg.yaml"
+    volumes:
+      - ./config/ULCL/upfcfg-1.yaml:/free5gc/config/upfcfg.yaml
+      - ./config/upf-iptables.sh:/free5gc/upf-iptables.sh
+    cap_add:
+      - NET_ADMIN
+    networks:
+      privnet:
+        aliases:
+          - upf-1.free5gc.org
+
+  free5gc-upf-2:
+    container_name: upf-2
+    image: free5gc/upf:v3.4.1
+    command: bash -c "./upf-iptables.sh && ./upf -c ./config/upfcfg.yaml"
+    volumes:
+      - ./config/ULCL/upfcfg-2.yaml:/free5gc/config/upfcfg.yaml
+      - ./config/upf-iptables.sh:/free5gc/upf-iptables.sh
+    cap_add:
+      - NET_ADMIN
+    networks:
+      privnet:
+        aliases:
+          - upf-2.free5gc.org
+
+  db:
+    container_name: mongodb
+    image: mongo:4.4
+    command: mongod --port 27017 --quiet
+    expose:
+      - "27017"
+    volumes:
+      - dbdata:/data/db
+    networks:
+      privnet:
+        aliases:
+          - db
+
+  free5gc-nrf:
+    container_name: nrf
+    image: free5gc/nrf:v3.4.1
+    command: ./nrf -c ./config/nrfcfg.yaml
+    expose:
+      - "8000"
+    volumes:
+      - ./config/nrfcfg.yaml:/free5gc/config/nrfcfg.yaml
+    environment:
+      DB_URI: mongodb://db/free5gc
+      GIN_MODE: release
+    networks:
+      privnet:
+        aliases:
+          - nrf.free5gc.org
+    depends_on:
+      - db
+
+  free5gc-amf:
+    container_name: amf
+    image: free5gc/amf:v3.4.1
+    command: ./amf -c ./config/amfcfg.yaml
+    expose:
+      - "8000"
+    volumes:
+      - ./config/amfcfg.yaml:/free5gc/config/amfcfg.yaml
+    environment:
+      GIN_MODE: release
+    networks:
+      privnet:
+        aliases:
+          - amf.free5gc.org
+    depends_on:
+      - free5gc-nrf
+
+  free5gc-ausf:
+    container_name: ausf
+    image: free5gc/ausf:v3.4.1
+    command: ./ausf -c ./config/ausfcfg.yaml
+    expose:
+      - "8000"
+    volumes:
+      - ./config/ausfcfg.yaml:/free5gc/config/ausfcfg.yaml
+    environment:
+      GIN_MODE: release
+    networks:
+      privnet:
+        aliases:
+          - ausf.free5gc.org
+    depends_on:
+      - free5gc-nrf
+
+  free5gc-nssf:
+    container_name: nssf
+    image: free5gc/nssf:v3.4.1
+    command: ./nssf -c ./config/nssfcfg.yaml
+    expose:
+      - "8000"
+    volumes:
+      - ./config/nssfcfg.yaml:/free5gc/config/nssfcfg.yaml
+    environment:
+      GIN_MODE: release
+    networks:
+      privnet:
+        aliases:
+          - nssf.free5gc.org
+    depends_on:
+      - free5gc-nrf
+
+  free5gc-pcf:
+    container_name: pcf
+    image: free5gc/pcf:v3.4.1
+    command: ./pcf -c ./config/pcfcfg.yaml
+    expose:
+      - "8000"
+    volumes:
+      - ./config/pcfcfg.yaml:/free5gc/config/pcfcfg.yaml
+    environment:
+      GIN_MODE: release
+    networks:
+      privnet:
+        aliases:
+          - pcf.free5gc.org
+    depends_on:
+      - free5gc-nrf
+
+  free5gc-smf:
+    container_name: smf
+    image: free5gc/smf-base
+    command: ./smf -c ./config/smfcfg.yaml -u ./config/uerouting.yaml
+    expose:
+      - "8000"
+    volumes:
+      - ./config/ULCL/smfcfg.yaml:/free5gc/config/smfcfg.yaml
+      - ./config/ULCL/uerouting.yaml:/free5gc/config/uerouting.yaml
+    environment:
+      GIN_MODE: release
+    networks:
+      privnet:
+        aliases:
+          - smf.free5gc.org
+    depends_on:
+      - free5gc-nrf
+      - free5gc-i-upf
+      - free5gc-upf-1
+      - free5gc-upf-2
+
+  free5gc-udm:
+    container_name: udm
+    image: free5gc/udm:v3.4.1
+    command: ./udm -c ./config/udmcfg.yaml
+    expose:
+      - "8000"
+    volumes:
+      - ./config/udmcfg.yaml:/free5gc/config/udmcfg.yaml
+    environment:
+      GIN_MODE: release
+    networks:
+      privnet:
+        aliases:
+          - udm.free5gc.org
+    depends_on:
+      - db
+      - free5gc-nrf
+
+  free5gc-udr:
+    container_name: udr
+    image: free5gc/udr:v3.4.1
+    command: ./udr -c ./config/udrcfg.yaml
+    expose:
+      - "8000"
+    volumes:
+      - ./config/udrcfg.yaml:/free5gc/config/udrcfg.yaml
+    environment:
+      DB_URI: mongodb://db/free5gc
+      GIN_MODE: release
+    networks:
+      privnet:
+        aliases:
+          - udr.free5gc.org
+    depends_on:
+      - db
+      - free5gc-nrf
+
+  free5gc-chf:
+    container_name: chf
+    image: free5gc/chf:v3.4.1
+    command: ./chf -c ./config/chfcfg.yaml
+    expose:
+      - "8000"
+    volumes:
+      - ./config/chfcfg.yaml:/free5gc/config/chfcfg.yaml
+    environment:
+      DB_URI: mongodb://db/free5gc
+      GIN_MODE: release
+    networks:
+      privnet:
+        aliases:
+          - chf.free5gc.org
+    depends_on:
+      - db
+      - free5gc-nrf
+      - free5gc-webui
+
+  free5gc-webui:
+    container_name: webui
+    image: free5gc/webui:v3.4.1
+    command: ./webui -c ./config/webuicfg.yaml
+    expose:
+      - "2122"
+      - "2121"
+    volumes:
+      - ./config/webuicfg.yaml:/free5gc/config/webuicfg.yaml
+    environment:
+      - GIN_MODE=release
+    networks:
+      privnet:
+        aliases:
+          - webui
+    ports:
+      - "5000:5000"
+      - "2122:2122"
+      - "2121:2121"
+    depends_on:
+      - db
+      - free5gc-nrf
+
+  ueransim:
+    container_name: ueransim
+    image: free5gc/ueransim:latest
+    command: ./nr-gnb -c ./config/gnbcfg.yaml
+    volumes:
+      - ./config/gnbcfg.yaml:/ueransim/config/gnbcfg.yaml
+      - ./config/uecfg.yaml:/ueransim/config/uecfg.yaml
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - "/dev/net/tun"
+    networks:
+      privnet:
+        aliases:
+          - gnb.free5gc.org
+    depends_on:
+      - free5gc-amf
+      - free5gc-i-upf
+      - free5gc-upf-1
+      - free5gc-upf-2
+
+  #ue:
+  #  container_name: ue
+  #  image: free5gc/ueransim:latest
+  #  command: ./nr-ue -c ./config/uecfg.yaml
+  #  volumes:
+  #    - ./config/uecfg.yaml:/ueransim/config/uecfg.yaml
+  #  cap_add:
+  #    - NET_ADMIN
+  #  devices:
+  #    - "/dev/net/tun"
+  #  networks:
+  #    privnet:
+  #      aliases:
+  #        - ue.free5gc.org
+  #  depends_on:
+  #    - ueransim
+    
+  #n3iwue:
+  #  container_name: n3iwue
+  #  image: free5gc/n3iwue:latest
+  #  command: sleep infinity
+  #  volumes:
+  #    - ./config/n3uecfg.yaml:/n3iwue/config/n3ue.yaml
+  #  cap_add:
+  #    - NET_ADMIN
+  #  devices:
+  #    - "/dev/net/tun"  
+  #  networks:
+  #    privnet:
+  #      aliases:
+  #        - n3ue.free5gc.org
+  #  depends_on:
+  #    - free5gc-n3iwf
+
+networks:
+  privnet:
+    ipam:
+      driver: default
+      config:
+        - subnet: 10.100.200.0/24
+    driver_opts:
+      com.docker.network.bridge.name: br-free5gc
+
+volumes:
+  dbdata:


### PR DESCRIPTION
Hi,

I noticed that there was no up-to date configuration available for the ULCL configuration example.

Instead of linking to an old branch or to a patch file, I suggest creating a separate folder (`config/ULCL`) and docker compose yaml (`docker-compose-ulcl.yaml`). This is similar to how the main free5gc repo handles this, and less error-prone in forgetting to incorporate updates to the config files :)

I have also adapted the README accordingly.

Hope this is helpful to anyone!

Cheers,
LaumiH