### PR TITLE
feat: add missing description for linking UERANSIM gNB and UE

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ docker logs smf
 
 Please refer to the [wiki](https://github.com/free5gc/free5gc/wiki) for more troubleshooting information.
 
-## Integration with external gNB/UE
+## Integration with (external) gNB/UE
 
 ### UERANSIM Notes
 
@@ -101,9 +101,10 @@ This [issue](https://github.com/free5gc/free5gc-compose/issues/28) provides deta
 By default, the provided UERANSIM service on this `docker-compose.yaml` will only act as a gNB. If you want to create a UE you'll need to:
 
 1. Create a subscriber through the WebUI. Follow the steps [here](https://free5gc.org/guide/Webconsole/Create-Subscriber-via-webconsole/#4-open-webconsole)
-2. Copy the `UE ID` field
-3. Change the value of `supi` on `config/uecfg.yaml` to the UE ID that you just copied
-4. Add an UE service on `docker-compose.yaml` as it follows:
+1. Copy the `UE ID` field
+1. Change the value of `supi` in `config/uecfg.yaml` to the UE ID that you just copied
+1. Change the `linkIp` in `config/gnbcfg.yaml` and the `gnbSearchList` in `config/uecfg.yaml` to a value other than localhost (e.g., `gnb.free5gc.org`) to enable communication between the services
+1. Add an UE service on `docker-compose.yaml` as it follows:
 
 ~~~yaml
   ue:

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ By default, the provided UERANSIM service on this `docker-compose.yaml` will onl
 1. Create a subscriber through the WebUI. Follow the steps [here](https://free5gc.org/guide/Webconsole/Create-Subscriber-via-webconsole/#4-open-webconsole)
 1. Copy the `UE ID` field
 1. Change the value of `supi` in `config/uecfg.yaml` to the UE ID that you just copied
-1. Change the `linkIp` in `config/gnbcfg.yaml` and the `gnbSearchList` in `config/uecfg.yaml` to a value other than localhost (e.g., `gnb.free5gc.org`) to enable communication between the services
+1. Change the `linkIp` in `config/gnbcfg.yaml` to `gnb.free5gc.org` (which is also present in the `gnbSearchList` in `config/uecfg.yaml`) to enable communication between the UE and gNB services
 1. Add an UE service on `docker-compose.yaml` as it follows:
 
 ~~~yaml

--- a/config/uecfg.yaml
+++ b/config/uecfg.yaml
@@ -21,6 +21,7 @@ imeiSv: "4370816125816151"
 # List of gNB IP addresses for Radio Link Simulation
 gnbSearchList:
   - 127.0.0.1
+  - gnb.free5gc.org
 
 # UAC Access Identities Configuration
 uacAic:


### PR DESCRIPTION
Hi,

while setting up free5gc compose with an integrated UERANSIM gNB and UE, I noticed that the documentation was missing a small detail: Before adding the `ue` service to the compose yaml, actually the values of the `linkIp` in `config/gnbcfg.yaml` and `gnbSearchList` in `config/uecfg.yaml` need to be replaced. The have `127.0.0.1` as of now, and thus are unable to communicate.

I suggest adding this small detail to the documentation to make it easier for newbies to get a first end-to-end 5GC with a gNB and UE running!

Cheers,
Laura