### PR TITLE
Bumpup golang version to 1.21.8-bullseye

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile responsible to create only the base image without compiling free5gc sources
 #
 
-FROM golang:1.18.10-bullseye AS builder
+FROM golang:1.21.8-bullseye AS builder
 
 LABEL maintainer="Free5GC <support@free5gc.org>"
 


### PR DESCRIPTION
Closes https://github.com/free5gc/free5gc-compose/issues/118