### PR TITLE
feat: Release v3.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ To start the core with a I-UPF and PSA-UPF ULCL configuration, use
 docker compose -f docker-compose-ulcl.yaml up
 ```
 
-> Note: This configuration have been tested using release [free5gc-compose v3.4.2](https://github.com/free5gc/free5gc-compose/tree/v3.4.2)
+> Note: This configuration have been tested using release [free5gc-compose v3.4.3](https://github.com/free5gc/free5gc-compose/tree/v3.4.3)
 
 Check out the used configuration files at `config/ULCL`.
 

--- a/config/n3iwfcfg.yaml
+++ b/config/n3iwfcfg.yaml
@@ -32,9 +32,9 @@ configuration:
   NASTCPPort: 20000 # TCP port which the NAS listens on
 
   # --- Nwu Interfaces ---
-  IKEBindAddress: n3iwf.free5gc.org # Nwu interface  IP address (IKE) on this N3IWF
-  IPSecTunnelAddress: 10.100.200.15 # Tunnel IP address of XFRM interface on this N3IWF
-  UEIPAddressRange: 10.100.200.0/24 # IP address pool allocated to UE in IPSec tunnel
+  IKEBindAddress: 10.100.200.15 # Nwu interface  IP address (IKE) on this N3IWF
+  IPSecTunnelAddress: 10.0.0.1 # Tunnel IP address of XFRM interface on this N3IWF
+  UEIPAddressRange: 10.0.0.0/24 # IP address pool allocated to UE in IPSec tunnel
   XFRMInterfaceName: xfrmi # Prefix of XFRM interface name created by N3IWF
   XFRMInterfaceID: 1 # XFRM interface if_id for IPSec routing (Any value except to 0, default value is 7 if not defined)
 

--- a/config/n3uecfg.yaml
+++ b/config/n3uecfg.yaml
@@ -3,8 +3,8 @@ info:
     description: Non-3GPP UE configuration
 configuration:
     N3IWFInformation:
-        IPSecIfaceAddr: n3iwf.free5gc.org # IP address of Nwu interface (IKE) on N3IWF
-        IPsecInnerAddr: n3iwf.free5gc.org # IP address of IPsec tunnel enpoint on N3IWF
+        IPSecIfaceAddr: 10.100.200.15 # IP address of Nwu interface (IKE) on N3IWF
+        IPsecInnerAddr: 10.0.0.1 # IP address of IPsec tunnel enpoint on N3IWF
     N3UEInformation:
         IMSI:
             PLMNID: # Public Land Mobile Network ID
@@ -13,7 +13,7 @@ configuration:
             MSIN: 0000001234 # Mobile Subscriber Identification Number (max 9 or 10 digits string, digit: 0~9)
         AMFID: cafe00 # For AMF identifier of GUAMI in AP-Parameter (hex string, 3 octets)
         IPSecIfaceName: eth0 # Name of Nwu interface (IKE) on this N3UE
-        IPSecIfaceAddr: n3ue.free5gc.org # IP address of Nwu interface (IKE) on this N3UE
+        IPSecIfaceAddr: 10.100.200.203 # IP address of Nwu interface (IKE) on this N3UE
         DnIPAddr: # IP address of domain network on this N3UE
         XfrmiId: 1 # Default XFRM interface if_id for routing, if_id of additional xfrmi will accumulate
         XfrmiName: ipsec # prefix of XFRM interface created

--- a/docker-compose-build.yaml
+++ b/docker-compose-build.yaml
@@ -20,12 +20,12 @@ services:
 
   db:
     container_name: mongodb
-    image: mongo:3.6.0
+    image: mongo:3.6.8
     command: mongod --port 27017
     expose:
       - "27017"
     volumes:
-      - dbdata:/data/db
+      - dbdata:/tmp/db
     networks:
       privnet:
         aliases:
@@ -345,7 +345,6 @@ networks:
         - subnet: 10.100.200.0/24
     driver_opts:
       com.docker.network.bridge.name: br-free5gc
-  
 
 volumes:
   dbdata:

--- a/docker-compose-build.yaml
+++ b/docker-compose-build.yaml
@@ -25,7 +25,7 @@ services:
     expose:
       - "27017"
     volumes:
-      - dbdata:/tmp/db
+      - dbdata:/data/db
     networks:
       privnet:
         aliases:

--- a/docker-compose-build.yaml
+++ b/docker-compose-build.yaml
@@ -20,7 +20,7 @@ services:
 
   db:
     container_name: mongodb
-    image: mongo
+    image: mongo:3.6.0
     command: mongod --port 27017
     expose:
       - "27017"
@@ -237,7 +237,7 @@ services:
       context: ./nf_n3iwf
       args:
         DEBUG_TOOLS: "false"
-    command: sh -c "./n3iwf-ipsec.sh && ./n3iwf -c ./config/n3iwfcfg.yaml"
+    command: ./n3iwf -c ./config/n3iwfcfg.yaml
     volumes:
       - ./config/n3iwfcfg.yaml:/free5gc/config/n3iwfcfg.yaml
       - ./config/n3iwf-ipsec.sh:/free5gc/n3iwf-ipsec.sh
@@ -322,7 +322,7 @@ services:
     container_name: n3iwue
     build:
       context: ./n3iwue
-    command: sleep infinity
+    command: bash -c "ip route del default && ip route add default via 10.100.200.1 dev eth0 metric 203 && sleep infinity"
     volumes:
       - ./config/n3uecfg.yaml:/n3iwue/config/n3ue.yaml
     cap_add:
@@ -331,6 +331,7 @@ services:
       - "/dev/net/tun"
     networks:
       privnet:
+        ipv4_address: 10.100.200.203
         aliases:
           - n3ue.free5gc.org
     depends_on:

--- a/docker-compose-ulcl-build.yaml
+++ b/docker-compose-ulcl-build.yaml
@@ -36,12 +36,12 @@ services:
           - psa-upf.free5gc.org
   db:
     container_name: mongodb
-    image: mongo:3.6.0
+    image: mongo:3.6.8
     command: mongod --port 27017 --quiet
     expose:
       - "27017"
     volumes:
-      - dbdata:/data/db
+      - dbdata:/tmp/db
     networks:
       privnet:
         aliases:

--- a/docker-compose-ulcl-build.yaml
+++ b/docker-compose-ulcl-build.yaml
@@ -41,7 +41,7 @@ services:
     expose:
       - "27017"
     volumes:
-      - dbdata:/tmp/db
+      - dbdata:/data/db
     networks:
       privnet:
         aliases:

--- a/docker-compose-ulcl-build.yaml
+++ b/docker-compose-ulcl-build.yaml
@@ -36,7 +36,7 @@ services:
           - psa-upf.free5gc.org
   db:
     container_name: mongodb
-    image: mongo
+    image: mongo:3.6.0
     command: mongod --port 27017 --quiet
     expose:
       - "27017"
@@ -295,7 +295,7 @@ services:
   #n3iwue:
   #  container_name: n3iwue
   #  image: free5gc/n3iwue:latest
-  #  command: sleep infinity
+  #  command: bash -c "ip route del default && ip route add default via 10.100.200.1 dev eth0 metric 203 && sleep infinity"
   #  volumes:
   #    - ./config/n3uecfg.yaml:/n3iwue/config/n3ue.yaml
   #  cap_add:
@@ -304,6 +304,7 @@ services:
   #    - "/dev/net/tun"
   #  networks:
   #    privnet:
+  #      ipv4_address: 10.100.200.203
   #      aliases:
   #        - n3ue.free5gc.org
   #  depends_on:

--- a/docker-compose-ulcl.yaml
+++ b/docker-compose-ulcl.yaml
@@ -31,12 +31,12 @@ services:
 
   db:
     container_name: mongodb
-    image: mongo:3.6.0
+    image: mongo:3.6.8
     command: mongod --port 27017 --quiet
     expose:
       - "27017"
     volumes:
-      - dbdata:/data/db
+      - dbdata:/tmp/db
     networks:
       privnet:
         aliases:

--- a/docker-compose-ulcl.yaml
+++ b/docker-compose-ulcl.yaml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   free5gc-i-upf:
     container_name: i-upf
-    image: free5gc/upf:v3.4.2
+    image: free5gc/upf:v3.4.3
     command: bash -c "./upf-iptables.sh && ./upf -c ./config/upfcfg.yaml"
     volumes:
       - ./config/ULCL/upfcfg-i-upf.yaml:/free5gc/config/upfcfg.yaml
@@ -17,7 +17,7 @@ services:
 
   free5gc-psa-upf:
     container_name: psa-upf
-    image: free5gc/upf:v3.4.2
+    image: free5gc/upf:v3.4.3
     command: bash -c "./upf-iptables.sh && ./upf -c ./config/upfcfg.yaml"
     volumes:
       - ./config/ULCL/upfcfg-psa-upf.yaml:/free5gc/config/upfcfg.yaml
@@ -44,7 +44,7 @@ services:
 
   free5gc-nrf:
     container_name: nrf
-    image: free5gc/nrf:v3.4.2
+    image: free5gc/nrf:v3.4.3
     command: ./nrf -c ./config/nrfcfg.yaml
     expose:
       - "8000"
@@ -62,7 +62,7 @@ services:
 
   free5gc-amf:
     container_name: amf
-    image: free5gc/amf:v3.4.2
+    image: free5gc/amf:v3.4.3
     command: ./amf -c ./config/amfcfg.yaml
     expose:
       - "8000"
@@ -79,7 +79,7 @@ services:
 
   free5gc-ausf:
     container_name: ausf
-    image: free5gc/ausf:v3.4.2
+    image: free5gc/ausf:v3.4.3
     command: ./ausf -c ./config/ausfcfg.yaml
     expose:
       - "8000"
@@ -96,7 +96,7 @@ services:
 
   free5gc-nssf:
     container_name: nssf
-    image: free5gc/nssf:v3.4.2
+    image: free5gc/nssf:v3.4.3
     command: ./nssf -c ./config/nssfcfg.yaml
     expose:
       - "8000"
@@ -113,7 +113,7 @@ services:
 
   free5gc-pcf:
     container_name: pcf
-    image: free5gc/pcf:v3.4.2
+    image: free5gc/pcf:v3.4.3
     command: ./pcf -c ./config/pcfcfg.yaml
     expose:
       - "8000"
@@ -130,7 +130,7 @@ services:
 
   free5gc-smf:
     container_name: smf
-    image: free5gc/smf:v3.4.2
+    image: free5gc/smf:v3.4.3
     command: ./smf -c ./config/smfcfg.yaml -u ./config/uerouting.yaml
     expose:
       - "8000"
@@ -150,7 +150,7 @@ services:
 
   free5gc-udm:
     container_name: udm
-    image: free5gc/udm:v3.4.2
+    image: free5gc/udm:v3.4.3
     command: ./udm -c ./config/udmcfg.yaml
     expose:
       - "8000"
@@ -168,7 +168,7 @@ services:
 
   free5gc-udr:
     container_name: udr
-    image: free5gc/udr:v3.4.2
+    image: free5gc/udr:v3.4.3
     command: ./udr -c ./config/udrcfg.yaml
     expose:
       - "8000"
@@ -187,7 +187,7 @@ services:
 
   free5gc-chf:
     container_name: chf
-    image: free5gc/chf:v3.4.2
+    image: free5gc/chf:v3.4.3
     command: ./chf -c ./config/chfcfg.yaml
     expose:
       - "8000"
@@ -207,7 +207,7 @@ services:
 
   free5gc-webui:
     container_name: webui
-    image: free5gc/webui:v3.4.2
+    image: free5gc/webui:v3.4.3
     command: ./webui -c ./config/webuicfg.yaml
     expose:
       - "2122"

--- a/docker-compose-ulcl.yaml
+++ b/docker-compose-ulcl.yaml
@@ -31,7 +31,7 @@ services:
 
   db:
     container_name: mongodb
-    image: mongo
+    image: mongo:3.6.0
     command: mongod --port 27017 --quiet
     expose:
       - "27017"
@@ -268,7 +268,7 @@ services:
   #n3iwue:
   #  container_name: n3iwue
   #  image: free5gc/n3iwue:latest
-  #  command: sleep infinity
+  #  command: bash -c "ip route del default && ip route add default via 10.100.200.1 dev eth0 metric 203 && sleep infinity"
   #  volumes:
   #    - ./config/n3uecfg.yaml:/n3iwue/config/n3ue.yaml
   #  cap_add:
@@ -277,6 +277,7 @@ services:
   #    - "/dev/net/tun"
   #  networks:
   #    privnet:
+  #      ipv4_address: 10.100.200.203
   #      aliases:
   #        - n3ue.free5gc.org
   #  depends_on:

--- a/docker-compose-ulcl.yaml
+++ b/docker-compose-ulcl.yaml
@@ -36,7 +36,7 @@ services:
     expose:
       - "27017"
     volumes:
-      - dbdata:/tmp/db
+      - dbdata:/data/db
     networks:
       privnet:
         aliases:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,12 +17,12 @@ services:
 
   db:
     container_name: mongodb
-    image: mongo:3.6.0
+    image: mongo:3.6.8
     command: mongod --port 27017
     expose:
       - "27017"
     volumes:
-      - dbdata:/data/db
+      - dbdata:/tmp/db
     networks:
       privnet:
         aliases:
@@ -237,7 +237,7 @@ services:
       - free5gc-amf
       - free5gc-smf
       - free5gc-upf
-      
+
   free5gc-webui:
     container_name: webui
     image: free5gc/webui:v3.4.2

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
     expose:
       - "27017"
     volumes:
-      - dbdata:/tmp/db
+      - dbdata:/data/db
     networks:
       privnet:
         aliases:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   free5gc-upf:
     container_name: upf
-    image: free5gc/upf:v3.4.2
+    image: free5gc/upf:v3.4.3
     command: bash -c "./upf-iptables.sh && ./upf -c ./config/upfcfg.yaml"
     volumes:
       - ./config/upfcfg.yaml:/free5gc/config/upfcfg.yaml
@@ -30,7 +30,7 @@ services:
 
   free5gc-nrf:
     container_name: nrf
-    image: free5gc/nrf:v3.4.2
+    image: free5gc/nrf:v3.4.3
     command: ./nrf -c ./config/nrfcfg.yaml
     expose:
       - "8000"
@@ -49,7 +49,7 @@ services:
 
   free5gc-amf:
     container_name: amf
-    image: free5gc/amf:v3.4.2
+    image: free5gc/amf:v3.4.3
     command: ./amf -c ./config/amfcfg.yaml
     expose:
       - "8000"
@@ -68,7 +68,7 @@ services:
 
   free5gc-ausf:
     container_name: ausf
-    image: free5gc/ausf:v3.4.2
+    image: free5gc/ausf:v3.4.3
     command: ./ausf -c ./config/ausfcfg.yaml
     expose:
       - "8000"
@@ -86,7 +86,7 @@ services:
 
   free5gc-nssf:
     container_name: nssf
-    image: free5gc/nssf:v3.4.2
+    image: free5gc/nssf:v3.4.3
     command: ./nssf -c ./config/nssfcfg.yaml
     expose:
       - "8000"
@@ -104,7 +104,7 @@ services:
 
   free5gc-pcf:
     container_name: pcf
-    image: free5gc/pcf:v3.4.2
+    image: free5gc/pcf:v3.4.3
     command: ./pcf -c ./config/pcfcfg.yaml
     expose:
       - "8000"
@@ -122,7 +122,7 @@ services:
 
   free5gc-smf:
     container_name: smf
-    image: free5gc/smf:v3.4.2
+    image: free5gc/smf:v3.4.3
     command: ./smf -c ./config/smfcfg.yaml -u ./config/uerouting.yaml
     expose:
       - "8000"
@@ -142,7 +142,7 @@ services:
 
   free5gc-udm:
     container_name: udm
-    image: free5gc/udm:v3.4.2
+    image: free5gc/udm:v3.4.3
     command: ./udm -c ./config/udmcfg.yaml
     expose:
       - "8000"
@@ -161,7 +161,7 @@ services:
 
   free5gc-udr:
     container_name: udr
-    image: free5gc/udr:v3.4.2
+    image: free5gc/udr:v3.4.3
     command: ./udr -c ./config/udrcfg.yaml
     expose:
       - "8000"
@@ -181,7 +181,7 @@ services:
 
   free5gc-chf:
     container_name: chf
-    image: free5gc/chf:v3.4.2
+    image: free5gc/chf:v3.4.3
     command: ./chf -c ./config/chfcfg.yaml
     expose:
       - "8000"
@@ -202,7 +202,7 @@ services:
 
   free5gc-n3iwf:
     container_name: n3iwf
-    image: free5gc/n3iwf:v3.4.2
+    image: free5gc/n3iwf:v3.4.3
     command: ./n3iwf -c ./config/n3iwfcfg.yaml
     volumes:
       - ./config/n3iwfcfg.yaml:/free5gc/config/n3iwfcfg.yaml
@@ -240,7 +240,7 @@ services:
 
   free5gc-webui:
     container_name: webui
-    image: free5gc/webui:v3.4.2
+    image: free5gc/webui:v3.4.3
     command: ./webui -c ./config/webuicfg.yaml
     expose:
       - "2121"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
 
   db:
     container_name: mongodb
-    image: mongo
+    image: mongo:3.6.0
     command: mongod --port 27017
     expose:
       - "27017"
@@ -203,7 +203,7 @@ services:
   free5gc-n3iwf:
     container_name: n3iwf
     image: free5gc/n3iwf:v3.4.2
-    command: sh -c "./n3iwf-ipsec.sh && ./n3iwf -c ./config/n3iwfcfg.yaml"
+    command: ./n3iwf -c ./config/n3iwfcfg.yaml
     volumes:
       - ./config/n3iwfcfg.yaml:/free5gc/config/n3iwfcfg.yaml
       - ./config/n3iwf-ipsec.sh:/free5gc/n3iwf-ipsec.sh
@@ -282,7 +282,7 @@ services:
   n3iwue:
     container_name: n3iwue
     image: free5gc/n3iwue:latest
-    command: sleep infinity
+    command: bash -c "ip route del default && ip route add default via 10.100.200.1 dev eth0 metric 203 && sleep infinity"
     volumes:
       - ./config/n3uecfg.yaml:/n3iwue/config/n3ue.yaml
     cap_add:
@@ -291,6 +291,7 @@ services:
       - "/dev/net/tun"
     networks:
       privnet:
+        ipv4_address: 10.100.200.203
         aliases:
           - n3ue.free5gc.org
     depends_on:


### PR DESCRIPTION
# Major Changes
- Release v3.4.3
- fix: n3iwf/n3iwue IPsec tunnel address and db version

## Description 
The changes fix an issue with the IPsec tunnel establishment by modifying the Docker Compose YAML and configuration YAML files. The update ensures that the correct peer/local IP and IPsec tunnel endpoint IP in the configuration, align with the code that uses net.ParseIP to fetch the IP address.

## Note
Additionally, MongoDB was downgraded to version 3.6.8 because the system does not have AVX support, which is required by MongoDB 5.0+. This downgrade resolves the warning:
  "WARNING: MongoDB 5.0+ requires a CPU with AVX support, and your current system does not appear to have that!"