### PR TITLE
Updated dockerfiles to remove build warnings due to docker syntax

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,7 +6,7 @@ FROM golang:1.21.8-bullseye AS builder
 
 LABEL maintainer="Free5GC <support@free5gc.org>"
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
 RUN apt-get update \

--- a/base/Dockerfile.nf
+++ b/base/Dockerfile.nf
@@ -2,9 +2,9 @@
 # Dockerfile responsible to compile specific NF from free5gc sources on the host
 #
 
-FROM free5gc/base as my-base
+FROM free5gc/base AS my-base
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 ARG F5GC_MODULE
 
 # Get Free5GC
@@ -20,7 +20,7 @@ WORKDIR /free5gc
 RUN mkdir -p cert/ public
 
 # Copy executables
-COPY --from=my-base /go/src/free5gc/bin/${F5GC_MODULE} ./
+COPY --from=my-base /go/src/free5gc/bin/ ./
 
 # Copy configuration files (not used for now)
 COPY --from=my-base /go/src/free5gc/config/* ./config/

--- a/base/Dockerfile.nf
+++ b/base/Dockerfile.nf
@@ -16,11 +16,13 @@ RUN cd $GOPATH/src/free5gc \
 # Alpine is used for debug purpose. You can use scratch for a smaller footprint.
 FROM alpine:3.15
 
+ARG F5GC_MODULE
+
 WORKDIR /free5gc
 RUN mkdir -p cert/ public
 
 # Copy executables
-COPY --from=my-base /go/src/free5gc/bin/ ./
+COPY --from=my-base /go/src/free5gc/bin/${F5GC_MODULE} ./
 
 # Copy configuration files (not used for now)
 COPY --from=my-base /go/src/free5gc/config/* ./config/

--- a/base/Dockerfile.nf.webconsole
+++ b/base/Dockerfile.nf.webconsole
@@ -2,9 +2,9 @@
 # Dockerfile responsible to compile webconsole NF from sources on the host
 #
 
-FROM free5gc/base as my-base
+FROM free5gc/base AS my-base
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Get Free5GC
 COPY free5gc/ $GOPATH/src/free5gc/

--- a/n3iwue/Dockerfile
+++ b/n3iwue/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.21.10-bullseye AS builder
 
 LABEL maintainer="Free5GC <support@free5gc.org>"
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
 RUN apt-get update \
@@ -14,7 +14,7 @@ RUN apt-get update \
 
 FROM bitnami/minideb:bullseye
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get install libsctp-dev lksctp-tools iproute2 iputils-ping procps psmisc tcpdump sudo -y \

--- a/nf_amf/Dockerfile
+++ b/nf_amf/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.15
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
-ENV F5GC_MODULE amf
+ENV F5GC_MODULE=amf
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)

--- a/nf_ausf/Dockerfile
+++ b/nf_ausf/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.15
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
-ENV F5GC_MODULE ausf
+ENV F5GC_MODULE=ausf
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)

--- a/nf_chf/Dockerfile
+++ b/nf_chf/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.15
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
-ENV F5GC_MODULE chf
+ENV F5GC_MODULE=chf
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)

--- a/nf_n3iwf/Dockerfile
+++ b/nf_n3iwf/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.15
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
-ENV F5GC_MODULE n3iwf
+ENV F5GC_MODULE=n3iwf
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)

--- a/nf_nef/Dockerfile
+++ b/nf_nef/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.15
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
-ENV F5GC_MODULE nef
+ENV F5GC_MODULE=nef
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)

--- a/nf_nrf/Dockerfile
+++ b/nf_nrf/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.15
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
-ENV F5GC_MODULE nrf
+ENV F5GC_MODULE=nrf
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)

--- a/nf_nssf/Dockerfile
+++ b/nf_nssf/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.15
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
-ENV F5GC_MODULE nssf
+ENV F5GC_MODULE=nssf
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)

--- a/nf_pcf/Dockerfile
+++ b/nf_pcf/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.15
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
-ENV F5GC_MODULE pcf
+ENV F5GC_MODULE=pcf
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)

--- a/nf_smf/Dockerfile
+++ b/nf_smf/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.15
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
-ENV F5GC_MODULE smf
+ENV F5GC_MODULE=smf
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)

--- a/nf_tngf/Dockerfile
+++ b/nf_tngf/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.15
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
-ENV F5GC_MODULE tngf
+ENV F5GC_MODULE=tngf
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)

--- a/nf_udm/Dockerfile
+++ b/nf_udm/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.15
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
-ENV F5GC_MODULE udm
+ENV F5GC_MODULE=udm
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)

--- a/nf_udr/Dockerfile
+++ b/nf_udr/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.15
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
-ENV F5GC_MODULE udr
+ENV F5GC_MODULE=udr
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)

--- a/nf_upf/Dockerfile
+++ b/nf_upf/Dockerfile
@@ -1,4 +1,4 @@
-FROM free5gc/base as my-base
+FROM free5gc/base AS my-base
 
 RUN git clone https://github.com/free5gc/go-gtp5gnl.git && mkdir "go-gtp5gnl/bin" && \
     cd "go-gtp5gnl/cmd/gogtp5g-tunnel" &&  go build -o "${GOPATH}/gtp5g-tunnel" . && \
@@ -10,8 +10,8 @@ FROM bitnami/minideb:bullseye
 LABEL description="free5GC open source 5G Core Network" \
     version="Stage 3"
 
-ENV F5GC_MODULE upf
-ENV DEBIAN_FRONTEND noninteractive
+ENV F5GC_MODULE=upf
+ENV DEBIAN_FRONTEND=noninteractive
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)

--- a/ueransim/Dockerfile
+++ b/ueransim/Dockerfile
@@ -2,7 +2,7 @@ FROM gcc:9.4.0 AS builder
 
 LABEL maintainer="Free5GC <support@free5gc.org>"
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
 RUN apt-get update \
@@ -16,7 +16,7 @@ RUN apt-get update \
 
 FROM bitnami/minideb:bullseye
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install runtime dependencies + ping
 RUN apt-get update \

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -4,8 +4,8 @@ FROM bitnami/minideb:bullseye
 LABEL description="Free5GC open source 5G Core Network" \
     version="Stage 3"
 
-ENV F5GC_MODULE webui
-ENV DEBIAN_FRONTEND noninteractive
+ENV F5GC_MODULE=webui
+ENV DEBIAN_FRONTEND=noninteractive
 ARG DEBUG_TOOLS
 
 # Install debug tools ~ 100MB (if DEBUG_TOOLS is set to true)


### PR DESCRIPTION
During the build process I was receiving warnings such as ```LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 7)``` and warnings for mismatch 'as' case with 'FROM' in the FROM AS statements. These syntax mistakes are highlighted in the Docker references for [legacy key value format](https://docs.docker.com/reference/build-checks/legacy-key-value-format/) and [from as casing](https://docs.docker.com/reference/build-checks/from-as-casing/) respectively. The changes remove the warnings when building the docker images from source and running `make all`. I also went ahead and double checked each Dockerfile for the individual components to ensure compliance with these two formatting recommendations. There are no warnings from Docker upon building any of the images anymore.

