### PR TITLE
feat: add daily release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release Docker images
 
 on:
+  schedule:
+    - cron: '14 18 * * *' # UTC 18:14 (Local 02:14)
   push:
     tags: [ 'v*.*.*' ]
     branches:


### PR DESCRIPTION
Add a daily release action scheduled at 2:14 AM (UTC+8) to prepare for ci-test in free5gc/free5gc repo running at 3:14 AM.

This ensures ci-test will always use the latest Docker images for testing procedures.