### PR TITLE
chore: add clean.sh on n3iwue Dockerfile

### DIFF
--- a/n3iwue/Dockerfile
+++ b/n3iwue/Dockerfile
@@ -26,5 +26,6 @@ RUN mkdir -p config/
 
 COPY --from=builder go/n3iwue/n3iwue .
 COPY --from=builder go/n3iwue/run.sh .
+COPY --from=builder go/n3iwue/clean.sh .
 
 VOLUME [ "/n3iwue/config" ]


### PR DESCRIPTION
## What's changed?
I noticed that `clean.sh` is not included in the `n3iwue`'s Dockerfile although it's referred in `run.sh`? This change will make it included.

## Working proofs
<img width="454" height="70" alt="スクリーンショット 2025-07-28 15 43 23" src="https://github.com/user-attachments/assets/04e83678-46fd-4fad-9ddc-e165b65bb37b" />
