### PR TITLE
Bump builder base image of ueransim to gcc 14.3.0 and CMake to 4.1.2

### DIFF
--- a/ueransim/Dockerfile
+++ b/ueransim/Dockerfile
@@ -1,23 +1,28 @@
-FROM gcc:9.4.0 AS builder
+FROM gcc:14.3.0 AS builder
 
 LABEL maintainer="Free5GC <support@free5gc.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="$PATH:/cmake/bin"
 
 ARG TARGET_ARCH=x86_64 
 # TARGET_ARCH support : x86_64, aarch64(arm64)
 
 # Install dependencies
 RUN apt-get update \
-    && apt-get install libsctp-dev lksctp-tools iproute2 -y \
-    && wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1-linux-${TARGET_ARCH}.sh -O cmake_installer.sh \
+    && apt-get install libsctp-dev lksctp-tools iproute2 make -y \
+    && mkdir /cmake \
+    && cd /cmake \
+    && wget https://github.com/Kitware/CMake/releases/download/v4.1.2/cmake-4.1.2-linux-${TARGET_ARCH}.sh -O cmake_installer.sh \
     && chmod +x cmake_installer.sh \
     && ./cmake_installer.sh --skip-license \
+    && cd .. \
     && git clone -b master -j `nproc` https://github.com/aligungr/UERANSIM \
     && cd ./UERANSIM \
-    && make
+    && make -j `nproc`
 
-FROM bitnami/minideb:bullseye
+
+FROM bitnami/minideb:trixie
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -29,6 +34,8 @@ RUN apt-get update \
 WORKDIR /ueransim
 
 RUN mkdir -p config/ binder/
+RUN mkdir -p /etc/iproute2
+RUN touch /etc/iproute2/rt_tables
 
 COPY --from=builder /UERANSIM/build/nr-gnb .
 COPY --from=builder /UERANSIM/build/nr-ue .


### PR DESCRIPTION
The builder of ueransim is no longer able to build the image due to EOL of Debian buster, the apt repo is removed from Fastly hosted deb.debian.org resulting in download failure
<img width="885" height="173" alt="截圖 2025-10-20 晚上9 58 15" src="https://github.com/user-attachments/assets/9abd0578-256c-4a7a-9106-f220d28f6b07" />

The CMake install script also have issue when running extracting in root directory, it will overwrite all files in /bin/, therefore creating a separated directory for CMake tool is necessary

If we would like to use gcc 15, then the modification of upstream makefile / code is required.
<img width="1323" height="644" alt="截圖 2025-10-20 晚上10 33 28" src="https://github.com/user-attachments/assets/60a8d8eb-2744-4953-8699-5511df8f2101" />
